### PR TITLE
ESP32-DIV v2.0 - FENRIR Upgrades: 8 New Features + 17 Bug Fixes

### DIFF
--- a/bleconfig.h
+++ b/bleconfig.h
@@ -2,6 +2,7 @@
 #define BLECONFIG_H
 
 #include "utils.h"
+#include "subconfig.h"  // For cleanupSubGHz() and subghz_receive_active
 
 #include <TFT_eSPI.h> 
 #include <PCF8574.h>

--- a/subconfig.h
+++ b/subconfig.h
@@ -17,6 +17,16 @@
 extern TFT_eSPI tft;
 extern PCF8574 pcf;
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Radio Switching Support - Pin 16 shared between CC1101 GDO0 and NRF24 CE
+// ═══════════════════════════════════════════════════════════════════════════
+namespace replayat {
+  extern RCSwitch mySwitch;           // RCSwitch instance for SubGHz receive
+  extern bool subghz_receive_active;  // Flag: true when CC1101 has pin 16 interrupt
+}
+
+// Cleanup function - call BEFORE switching FROM SubGHz TO 2.4GHz modes
+void cleanupSubGHz();
 
 #define XPT2046_IRQ   34
 #define XPT2046_MOSI  32


### PR DESCRIPTION
## Summary

Major firmware upgrade with 8 new features, 17 bug fixes, and full touchscreen support.

### New Features
- **2.4GHz Spectrum Analyzer** - FFT-based visualization across 2.4GHz band
- **WLAN Jammer** - NRF24-based WiFi disruption with channel hopping
- **Proto Kill** - Multi-protocol 2.4GHz IoT disruption
- **SubGHz Brute Force** - Automated attacks for Linear, CAME, Nice, Chamberlain, DoorHan, GateTX
- **BLE Sniffer** - Passive capture with RSSI proximity detection
- **Brightness Control** - Touch slider interface
- **Screen Timeout** - Configurable auto-sleep
- **Full Touch Support** - All menus now touch-enabled

### Critical Bug Fixes
| Priority | File | Issue |
|----------|------|-------|
| HIGH | wifi.cpp:2559 | Buffer overflow in deauth frame |
| HIGH | subghz.cpp:1839 | Wrong modulation (2-FSK→ASK/OOK) for garage doors/Tesla |
| HIGH | ESP32-DIV.ino:240 | Global init before hardware ready |
| HIGH | icon.h | Missing header guards |
| HIGH | subghz.cpp:1323 | Integer underflow on profile delete |
| MEDIUM | subghz.cpp:1531 | SCREEN_HEIGHT 64→320 (was OLED value) |
| MEDIUM | wifi.cpp:3040 | Double scanNetworks() call |

Plus 10 additional cleanup fixes.

### Testing
- Tested on ESP32 Dev Module
- 2.4" TFT LCD (240x320) + XPT2046 Touch Controller
- CC1101 SubGHz + NRF24L01+ radios
- Build: 1,845,325 bytes (58% storage), 89,672 bytes RAM (27%)

### Author
HaleHound Security (FENRIR Division)