### PR TITLE
Fix wrong if statement in wifi.cpp

### DIFF
--- a/ESP32-DIV/wifi.cpp
+++ b/ESP32-DIV/wifi.cpp
@@ -1099,10 +1099,10 @@ void runUI() {
         if (millis() - lastSpamTime >= 50) {
           spammer();
 
-          if (activeIcon = 3) {
+          if (activeIcon == 3) {
             output();
           }
-          if (activeIcon = 3) {
+          if (activeIcon == 3) {
             animationState = 5;
           }
           lastSpamTime = millis();


### PR DESCRIPTION
Fixed assignment operator used instead of comparison in wifi.cpp lines 1102 and 1105.

Same type of bug as PR #52.