### PR TITLE
chore: add GitHub issue templates, PR template, and Arduino CI workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a problem with ESP32-DIV firmware or hardware
+labels: bug
+---
+
+## Bug Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- **Board**: ESP32-DIV (version: )
+- **Arduino IDE version**: 
+- **OS**: 
+- **Libraries installed** (list relevant ones):
+
+## Serial Output / Error Log
+
+```
+Paste your serial output or error log here
+```
+
+## Additional Context
+
+Add any other context, screenshots, or files about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in ESP32-DIV
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before submitting**, please:
+        - Search [existing issues](https://github.com/cifertech/ESP32-DIV/issues) to avoid duplicates.
+        - Check the [Troubleshooting & FAQ](../../README.md#troubleshooting--faq) section.
+
+  - type: dropdown
+    id: firmware_version
+    attributes:
+      label: Firmware Version
+      description: Which version of ESP32-DIV firmware are you running?
+      options:
+        - v1.6.0 (latest)
+        - v1.5.3
+        - v1.5.0
+        - v1.4.x or older
+        - Custom / DIY build
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hardware_revision
+    attributes:
+      label: Hardware Revision
+      description: Which hardware are you using?
+      options:
+        - ESP32-DIV v2 (Main board + Shield)
+        - ESP32-DIV v1 (Main board + Shield)
+        - Main board only (no shield)
+        - DIY / custom build
+    validations:
+      required: true
+
+  - type: input
+    id: arduino_ide_version
+    attributes:
+      label: Arduino IDE Version
+      placeholder: "e.g. 2.3.2"
+    validations:
+      required: true
+
+  - type: input
+    id: esp32_package_version
+    attributes:
+      label: ESP32 Board Package Version
+      description: Check under Tools > Board > Boards Manager
+      placeholder: "e.g. 3.0.5 (Espressif Systems)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_feature
+    attributes:
+      label: Affected Feature / Module
+      description: Which feature is affected?
+      options:
+        - Wi-Fi (Scanner / Deauther / Beacon Spammer / Captive Portal / etc.)
+        - Bluetooth (BLE Scanner / Jammer / Spoofer / Sour Apple / etc.)
+        - 2.4GHz (Scanner / Protokill)
+        - Sub-GHz (Replay / Jammer / CC1101)
+        - Infrared (IR)
+        - RFID / NFC
+        - GPS / Wardriver
+        - Touchscreen / UI
+        - SD Card
+        - Firmware Flashing / OTA
+        - Power / Battery
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a clear, numbered list of steps.
+      placeholder: |
+        1. Go to ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behaviour
+    attributes:
+      label: Expected Behaviour
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behaviour
+    attributes:
+      label: Actual Behaviour
+      description: What actually happens? Include any error messages shown on screen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: serial_output
+    attributes:
+      label: Serial Output / Logs
+      description: Paste relevant serial monitor output here (if available).
+      render: text
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Photos, videos, schematic modifications, or any other useful information.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature Request
+description: Suggest a new feature or improvement for ESP32-DIV
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an improvement!
+        Please check [existing issues](https://github.com/cifertech/ESP32-DIV/issues?q=label%3Aenhancement) before submitting to avoid duplicates.
+
+  - type: dropdown
+    id: feature_category
+    attributes:
+      label: Feature Category
+      description: Which part of the project does this relate to?
+      options:
+        - Wi-Fi
+        - Bluetooth / BLE
+        - 2.4GHz (NRF24)
+        - Sub-GHz (CC1101)
+        - Infrared (IR)
+        - RFID / NFC
+        - GPS
+        - UI / Display
+        - SD Card / File Management
+        - Hardware / PCB
+        - Firmware / OTA
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem / Motivation
+      description: Is your feature request related to a problem? Describe it clearly.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative approaches or workarounds?
+
+  - type: dropdown
+    id: hardware_required
+    attributes:
+      label: Does this require new or additional hardware?
+      options:
+        - "No — firmware/software only"
+        - "Yes — requires new module or component"
+        - "Unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Add any sketches, references, datasheets, or links that support your request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+## Description
+
+Briefly describe **what** this PR changes and **why**.
+
+Fixes # (issue number, if applicable)
+
+---
+
+## Type of Change
+
+<!-- Put an `x` inside the brackets that apply -->
+
+- [ ] `feat` — New feature or module
+- [ ] `fix` — Bug fix
+- [ ] `docs` — Documentation only
+- [ ] `refactor` — Code refactor (no feature or fix)
+- [ ] `chore` — Build, CI, dependency update
+- [ ] `style` — Formatting / whitespace only
+
+---
+
+## Hardware Tested On
+
+<!-- Check all that you have tested with -->
+
+- [ ] ESP32-DIV v2 (Main board + Shield)
+- [ ] ESP32-DIV v1 (Main board + Shield)
+- [ ] Main board only (no shield)
+- [ ] DIY / custom build
+- [ ] Not applicable (docs / CI only)
+
+---
+
+## Checklist
+
+- [ ] My branch is up to date with `main` (`git fetch upstream && git rebase upstream/main`)
+- [ ] I have tested the change on actual hardware (or noted why this is not applicable)
+- [ ] The sketch compiles without errors in Arduino IDE with the correct board settings
+- [ ] I have not introduced any new blocking `delay()` calls > 200 ms in feature loops
+- [ ] New display code uses the theme constants from `shared.h` (`UI_BG`, `UI_FG`, `UI_TEXT`, etc.)
+- [ ] I have updated the README / Wiki if my change affects user-facing behaviour
+- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
+
+---
+
+## Screenshots / Video (if applicable)
+
+<!-- Drag and drop images or paste a link to a short video showing the change on the device -->
+
+---
+
+## Additional Notes
+
+<!-- Anything else reviewers should know? -->

--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -1,0 +1,78 @@
+# ============================================================
+# Arduino Compile Check
+# Verifies that the ESP32-DIV sketch compiles cleanly on every
+# push to main and on every pull request targeting main.
+# ============================================================
+
+name: Arduino Compile Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ESP32-DIV/**'
+      - '.github/workflows/arduino-compile.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ESP32-DIV/**'
+      - '.github/workflows/arduino-compile.yml'
+
+jobs:
+  compile:
+    name: Compile Sketch (ESP32-S3)
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── 1. Check out source ─────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ── 2. Set up Arduino CLI ────────────────────────────────
+      - name: Set up Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+
+      # ── 3. Install the Espressif ESP32 board package ─────────
+      - name: Install ESP32 board package
+        run: |
+          arduino-cli core update-index \
+            --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          arduino-cli core install esp32:esp32 \
+            --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+
+      # ── 4. Install required libraries ────────────────────────
+      - name: Install libraries from Library Manager
+        run: |
+          arduino-cli lib install \
+            "TFT_eSPI" \
+            "PCF8574" \
+            "XPT2046_Touchscreen" \
+            "NimBLE-Arduino" \
+            "RCSwitch" \
+            "arduinoFFT"
+
+      # ── 5. Copy bundled libraries (not on Library Manager) ───
+      - name: Install bundled libraries
+        run: |
+          ARDUINO_LIB_DIR=$(arduino-cli config dump | grep 'user:' | awk '{print $2}')/libraries
+          cp -r Libraries/* "$ARDUINO_LIB_DIR/"
+
+      # ── 6. Compile the sketch ────────────────────────────────
+      - name: Compile ESP32-DIV sketch
+        run: |
+          arduino-cli compile \
+            --fqbn esp32:esp32:esp32s3:FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,PSRAM=opi \
+            --warnings default \
+            ESP32-DIV/ESP32-DIV.ino
+
+      # ── 7. Upload compile artifacts (optional, 7-day retention)
+      - name: Upload compiled binary
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: esp32-div-firmware
+          path: |
+            /tmp/arduino-sketch-*/ESP32-DIV.ino.bin
+            /tmp/arduino-sketch-*/ESP32-DIV.ino.elf
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

This PR adds GitHub community health files and CI automation to improve contributor experience and code quality for the ESP32-DIV project.

## Changes

### `.github/ISSUE_TEMPLATE/bug_report.md`
Structured bug report template prompting contributors to include:
- Steps to reproduce
- Expected vs actual behavior
- Board version, Arduino IDE version, OS
- Serial output / error log

### `.github/ISSUE_TEMPLATE/bug_report.yml` & `feature_request.yml`
YAML-based issue form templates for guided issue creation via GitHub's issue form UI.

### `.github/PULL_REQUEST_TEMPLATE.md`
PR template with:
- Description + linked issue field
- Type of change checklist
- Testing notes section (hardware, IDE version, libraries)
- Contributor checklist (code style, compilation, docs)

### `.github/workflows/arduino-compile.yml`
CI workflow that automatically compiles the ESP32-DIV sketch on every push and pull request to `main`. Installs all required libraries and the ESP32 board package via `arduino-cli`.

## Motivation

The repository currently has no issue templates or PR templates, leading to inconsistent bug reports (many missing critical info like board version or serial output). This PR establishes baseline GitHub community standards and automated compile checking to catch build regressions early.

## Testing

Files follow standard GitHub template formats. The CI workflow was validated against the existing library list in the project README and source code.