### PR TITLE
Fix reboot in WiFi scanner from SSID buffer overflow

### DIFF
--- a/ESP32-DIV/wifi.cpp
+++ b/ESP32-DIV/wifi.cpp
@@ -1841,7 +1841,7 @@ static int last_rendered_index = -1;
 
 static void drawNetworkRow(int i, int y, bool isSel) {
   char buf[64];
-  char ssid[12];
+  char ssid[16];  // 11 chars + "..." + NUL; must leave room for the ellipsis below
   String fullSSID = WiFi.SSID(i);
   strncpy(ssid, fullSSID.c_str(), 11);
   ssid[11] = '\0';
@@ -3602,7 +3602,7 @@ void drawScanScreen() {
 
         for (int i = start_index; i < end_index && y < LIST_BOTTOM_Y; i++) {
             char buf[64];
-            char ssid[12];
+            char ssid[16];  // 11 chars + "..." + NUL
             strncpy(ssid, (char*)ap_list[i].ssid, 11);
             ssid[11] = '\0';
             if (strlen((char*)ap_list[i].ssid) > 11) strcat(ssid, "...");
@@ -4225,7 +4225,7 @@ void drawScanScreen() {
 
         for (int i = start_index; i < end_index && y < LIST_BOTTOM_Y; i++) {
             char buf[64];
-            char ssid[12];
+            char ssid[16];  // 11 chars + "..." + NUL
             strncpy(ssid, (char*)ap_list[i].ssid, 11);
             ssid[11] = '\0';
             if (strlen((char*)ap_list[i].ssid) > 11) strcat(ssid, "...");
@@ -5396,7 +5396,7 @@ bool selectWiFiNetwork() {
     for (int i = startIndex; i < end_index && y_pos < 300; i++) {
       if (x >= 10 && x < SCREEN_WIDTH - 10 && y >= y_pos && y < y_pos + NETWORK_ROW_HEIGHT) {
         char buf[64];
-        char ssid[12];
+        char ssid[16];  // 11 chars + "..." + NUL
         strncpy(ssid, networks[i].ssid, 11);
         ssid[11] = '\0';
         if (strlen(networks[i].ssid) > 11) strcat(ssid, "...");
@@ -5463,7 +5463,7 @@ void drawNetworkList(int startIndex, int numNetworks, NetworkInfo* networks, int
 
     for (int i = start_index; i < end_index && y < 300; i++) {
       char buf[64];
-      char ssid[12];
+      char ssid[16];  // 11 chars + "..." + NUL
       strncpy(ssid, networks[i].ssid, 11);
       ssid[11] = '\0';
       if (strlen(networks[i].ssid) > 11) strcat(ssid, "...");


### PR DESCRIPTION
Problem: Opening the WiFi Scanner reboots the device a few seconds after it starts, whenever a nearby network has an SSID longer than 11 characters. (Worked in v1.5, broke in v1.6.)
Cause: In wifi.cpp, drawNetworkRow() and four sibling list renderers copy the SSID into char ssid[12], fully filling it (11 chars + NUL), then call strcat(ssid, "...") for long SSIDs — writing 4 bytes past the buffer and corrupting the stack.
Fix: Enlarge those buffers to ssid[16] (room for 11 + "..." + NUL). v1.5 used ssid[32], which is why it wasn't affected.
Tested on hardware (ESP32): WiFi Scanner now lists networks with long SSIDs without rebooting.