### PR TITLE
feat: add hardware status indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Build e TFT
 
 - Fixed the ESP32-S3 link conflict by making `ieee80211_raw_frame_sanity_check` weak in `wifi.cpp`.
-- Restored the TFT display on ESP32-DIV V2/V2.1 by applying the recommended local TFT_eSPI V2 `User_Setup.h` configuration.
+- Restored the TFT display on ESP32-DIV V2/V2.0 by applying the recommended local TFT_eSPI V2 `User_Setup.h` configuration.
 - Added boot diagnostics around battery read, menu draw, status bar draw, and touchscreen startup.
 
 ### Buzzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## Unreleased
+
+### Build e TFT
+
+- Fixed the ESP32-S3 link conflict by making `ieee80211_raw_frame_sanity_check` weak in `wifi.cpp`.
+- Restored the TFT display on ESP32-DIV V2/V2.1 by applying the recommended local TFT_eSPI V2 `User_Setup.h` configuration.
+- Added boot diagnostics around battery read, menu draw, status bar draw, and touchscreen startup.
+
+### Buzzer
+
+- Added non-blocking `BuzzerService` with boot success and SubGHz capture feedback.
+- Confirmed the integrated buzzer on GPIO 2 and enabled `BUZZER_PIN`.
+- Tuned the boot/capture beep volume and duration for a quieter startup sound.
+
+### WS2812B status LEDs
+
+- Added non-blocking `StatusLedService` for the 4 onboard WS2812B LEDs.
+- Confirmed the WS2812B data input on GPIO 1 from the V2 schematic and enabled `STATUS_LED_PIN`.
+- Gated LED output behind `settings().neopixelEnabled`, so the LEDs remain off when NeoPixel is disabled in settings.
+- Added WS2812 feedback for boot, idle, Wi-Fi scan, BLE scan, and SubGHz capture events.
+- Kept WS2812 scan animations alive during blocking Wi-Fi/BLE scans.
+
+### Status bar and icons
+
+- Added real Wi-Fi/BLE status bar state handling for `off`, `scanning`, `active`, and `error`.
+- Updated foreground Wi-Fi/BLE scans to force status bar redraws when scanning starts and finishes.
+- Preserved manual Wi-Fi/BLE scan counts in the status bar even when auto-scan is disabled.
+- Replaced the unknown battery text with a USB-powered battery icon with a lightning bolt when battery voltage is unavailable.
+
+### Battery safety
+
+- Made battery reads safe when `BATTERY_ADC_PIN` is not configured, avoiding `analogRead(-1)`.
+- Fixed the status bar task so unknown battery voltage is not converted into a fake percentage.
+
+### Hardware map
+
+- Added initial `BoardPins_ESP32DIV_V2.h` documentation for validated pins and known future-module conflicts.

--- a/ESP32-DIV/BoardPins_ESP32DIV_V2.h
+++ b/ESP32-DIV/BoardPins_ESP32DIV_V2.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * ESP32-DIV V2/V2.1 hardware map.
+ * ESP32-DIV V2/V2.0 hardware map.
  *
  * This file is intentionally documentary for now. Do not include it from
  * shared.h until each pin has been validated on the target hardware.

--- a/ESP32-DIV/BoardPins_ESP32DIV_V2.h
+++ b/ESP32-DIV/BoardPins_ESP32DIV_V2.h
@@ -1,0 +1,72 @@
+#pragma once
+
+/*
+ * ESP32-DIV V2/V2.1 hardware map.
+ *
+ * This file is intentionally documentary for now. Do not include it from
+ * shared.h until each pin has been validated on the target hardware.
+ */
+
+#define ESP32DIV_V2_HW_INTERNAL_DISPLAY_TOUCH 1
+#define ESP32DIV_V2_HW_INTERNAL_SD            1
+#define ESP32DIV_V2_HW_INTERNAL_BUTTONS       1
+#define ESP32DIV_V2_HW_INTERNAL_BUZZER        1
+#define ESP32DIV_V2_HW_INTERNAL_WS2812B       1
+
+#define ESP32DIV_V2_HW_EXTERNAL_CC1101        1
+#define ESP32DIV_V2_HW_EXTERNAL_NRF24         1
+#define ESP32DIV_V2_HW_EXTERNAL_IR            1
+
+#define ESP32DIV_V2_HW_FUTURE_PN532           1
+#define ESP32DIV_V2_HW_FUTURE_GPS             1
+
+/*
+ * Buzzer
+ *
+ * Validated on target hardware: buzzer is on IO2.
+ */
+#define ESP32DIV_V2_BUZZER_PIN_CANDIDATE      2
+#define ESP32DIV_V2_BUZZER_PIN_CONFIRMED      1
+
+/*
+ * WS2812B status LEDs
+ *
+ * V2 schematic: D1 DIN is driven from IO1 through R33 (1k). D1/D2 then chain
+ * through WSD to D3/D4.
+ */
+#define ESP32DIV_V2_WS2812B_COUNT             4
+#define ESP32DIV_V2_WS2812B_PIN_CANDIDATE     1
+#define ESP32DIV_V2_WS2812B_PIN_CONFIRMED     1
+
+/*
+ * Future PN532 RFID/NFC module
+ *
+ * PN532 is not installed yet. Existing defaults in shared.h use SPI and can
+ * conflict with NRF24 if the chip-select line overlaps.
+ */
+#define ESP32DIV_V2_PN532_INSTALLED           0
+#define ESP32DIV_V2_PN532_INTERFACE_SPI       1
+#define ESP32DIV_V2_PN532_CONFLICTS_NRF24_CS  1
+
+/*
+ * Future GPS module
+ *
+ * GPS is not installed yet. Existing default UART pins for the ESP32-S3 target
+ * are GPIO 47/48, which overlap the default NRF24 #2 CE/CSN pins.
+ */
+#define ESP32DIV_V2_GPS_INSTALLED             0
+#define ESP32DIV_V2_GPS_INTERFACE_UART        1
+#define ESP32DIV_V2_GPS_RX_PIN_CANDIDATE      47
+#define ESP32DIV_V2_GPS_TX_PIN_CANDIDATE      48
+#define ESP32DIV_V2_GPS_CONFLICTS_NRF24_2     1
+
+/*
+ * Known pin conflicts from current shared.h defaults.
+ *
+ * - PN532_SS defaults to GPIO 4, same as NRF24 #1 CSN on the ESP32-S3 profile.
+ * - GPS UART defaults to GPIO 47/48, same as NRF24 #2 CE/CSN.
+ * - IR defaults to GPIO 21/14, same as NRF24 #3 CSN/CE.
+ */
+#define ESP32DIV_V2_CONFLICT_PN532_NRF24_1    1
+#define ESP32DIV_V2_CONFLICT_GPS_NRF24_2      1
+#define ESP32DIV_V2_CONFLICT_IR_NRF24_3       1

--- a/ESP32-DIV/BuzzerService.cpp
+++ b/ESP32-DIV/BuzzerService.cpp
@@ -1,0 +1,79 @@
+#include "BuzzerService.h"
+
+#include "shared.h"
+
+namespace BuzzerService {
+namespace {
+constexpr uint8_t kLedcChannel = 7;
+constexpr uint8_t kLedcResolution = 8;
+constexpr uint16_t kBaseFrequency = 4000;
+
+bool s_available = false;
+bool s_active = false;
+uint32_t s_offAtMs = 0;
+
+bool pinIsValid() {
+#if defined(BUZZER_PIN)
+  return BUZZER_PIN >= 0;
+#else
+  return false;
+#endif
+}
+
+void startTone(uint16_t hz, uint16_t durationMs) {
+  if (!s_available || hz == 0 || durationMs == 0) {
+    return;
+  }
+
+  ledcWriteTone(kLedcChannel, hz);
+  s_active = true;
+  s_offAtMs = millis() + durationMs;
+}
+}
+
+void begin() {
+  s_available = pinIsValid();
+  s_active = false;
+
+  if (!s_available) {
+    return;
+  }
+
+  ledcSetup(kLedcChannel, kBaseFrequency, kLedcResolution);
+  ledcAttachPin(BUZZER_PIN, kLedcChannel);
+  ledcWriteTone(kLedcChannel, 0);
+}
+
+void loop() {
+  if (!s_available || !s_active) {
+    return;
+  }
+
+  if ((int32_t)(millis() - s_offAtMs) < 0) {
+    return;
+  }
+
+  ledcWriteTone(kLedcChannel, 0);
+  s_active = false;
+}
+
+void beepClick() {
+  startTone(1800, 25);
+}
+
+void beepSuccess() {
+  startTone(1800, 35);
+}
+
+void beepError() {
+  startTone(500, 120);
+}
+
+void beepCapture() {
+  startTone(2600, 70);
+}
+
+void beepWarning() {
+  startTone(1200, 90);
+}
+}

--- a/ESP32-DIV/BuzzerService.h
+++ b/ESP32-DIV/BuzzerService.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace BuzzerService {
+void begin();
+void loop();
+
+void beepClick();
+void beepSuccess();
+void beepError();
+void beepCapture();
+void beepWarning();
+}

--- a/ESP32-DIV/ESP32-DIV.ino
+++ b/ESP32-DIV/ESP32-DIV.ino
@@ -2,7 +2,9 @@
 #include <PCF8574.h>
 #include <TFT_eSPI.h>
 #include <Wire.h>
+#include "BuzzerService.h"
 #include "SettingsStore.h"
+#include "StatusLedService.h"
 #include "Touchscreen.h"
 #include "config.h"
 #include "ducky.h"
@@ -3297,6 +3299,7 @@ void setup() {
 
   Serial.begin(115200);
   Serial.println("[boot] start");
+  BuzzerService::begin();
 
   tft.init();
   tft.setRotation(TFT_ROTATION);
@@ -3320,6 +3323,8 @@ void setup() {
   settingsLoad();
   applyThemeToPalette(settings().theme);
   setBrightness(settings().brightness);
+  StatusLedService::begin();
+  StatusLedService::setMode(StatusLedService::Mode::Boot);
 
 #if HAS_PCF8574_BUTTONS
   if (!initPcf8574Buttons()) {
@@ -3343,17 +3348,26 @@ void setup() {
 
   Serial.println("[boot] draw menu");
   menu_initialized = false;
+  Serial.println("[boot] read battery");
   currentBatteryVoltage = readBatteryVoltage();
+  Serial.println("[boot] display menu");
   displayMenu();
+  Serial.println("[boot] draw status");
   drawStatusBar(currentBatteryVoltage, false);
 
+  Serial.println("[boot] setup touchscreen");
   setupTouchscreen();
 
   last_interaction_time = millis();
   Serial.println("[boot] ready");
+  BuzzerService::beepSuccess();
+  StatusLedService::setMode(StatusLedService::Mode::Idle);
+  StatusLedService::event(StatusLedService::Event::BootOk);
 }
 
 void loop() {
+  BuzzerService::loop();
+  StatusLedService::loop();
   applyThemeToPalette(settings().theme);
   handleButtons();
   updateStatusBar();

--- a/ESP32-DIV/StatusLedService.cpp
+++ b/ESP32-DIV/StatusLedService.cpp
@@ -1,0 +1,234 @@
+#include "StatusLedService.h"
+
+#include <Adafruit_NeoPixel.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "SettingsStore.h"
+#include "shared.h"
+
+namespace StatusLedService {
+namespace {
+constexpr uint8_t kBrightness = 32;
+constexpr uint32_t kFrameMs = 120;
+constexpr uint32_t kEventMs = 650;
+
+Adafruit_NeoPixel s_pixels(STATUS_LED_COUNT, STATUS_LED_PIN, NEO_GRB + NEO_KHZ800);
+Mode s_mode = Mode::Off;
+Event s_event = Event::BootOk;
+bool s_available = false;
+bool s_started = false;
+bool s_eventActive = false;
+volatile bool s_activityTaskRun = false;
+TaskHandle_t s_activityTask = nullptr;
+uint32_t s_lastFrameMs = 0;
+uint32_t s_eventUntilMs = 0;
+uint8_t s_phase = 0;
+
+bool pinIsValid() {
+#if defined(STATUS_LED_PIN)
+  return STATUS_LED_PIN >= 0;
+#else
+  return false;
+#endif
+}
+
+bool enabled() {
+  return s_available && settings().neopixelEnabled;
+}
+
+uint32_t color(uint8_t r, uint8_t g, uint8_t b) {
+  return s_pixels.Color(r, g, b);
+}
+
+void clearPixels() {
+  for (uint16_t i = 0; i < STATUS_LED_COUNT; ++i) {
+    s_pixels.setPixelColor(i, 0);
+  }
+}
+
+void showSolid(uint32_t c) {
+  for (uint16_t i = 0; i < STATUS_LED_COUNT; ++i) {
+    s_pixels.setPixelColor(i, c);
+  }
+  s_pixels.show();
+}
+
+void showChase(uint32_t c) {
+  clearPixels();
+  if (STATUS_LED_COUNT > 0) {
+    s_pixels.setPixelColor(s_phase % STATUS_LED_COUNT, c);
+  }
+  s_pixels.show();
+}
+
+void renderMode() {
+  switch (s_mode) {
+    case Mode::Off:
+      clearPixels();
+      s_pixels.show();
+      break;
+    case Mode::Boot:
+      showChase(color(24, 24, 24));
+      break;
+    case Mode::Idle:
+      showSolid(color(0, 0, 4));
+      break;
+    case Mode::WifiScan:
+      showChase(color(0, 18, 0));
+      break;
+    case Mode::BleScan:
+      showChase(color(0, 8, 18));
+      break;
+    case Mode::SubGhzActivity:
+      showChase(color(22, 10, 0));
+      break;
+    case Mode::Nrf24Activity:
+      showChase(color(12, 0, 20));
+      break;
+    case Mode::SdError:
+      showSolid(color(24, 0, 0));
+      break;
+    case Mode::BatteryLow:
+      showSolid((s_phase & 1) ? color(24, 0, 0) : 0);
+      break;
+    case Mode::GpsSearching:
+      showChase(color(0, 12, 10));
+      break;
+    case Mode::GpsFix:
+      showSolid(color(0, 18, 4));
+      break;
+  }
+}
+
+void renderEvent() {
+  switch (s_event) {
+    case Event::BootOk:
+      showSolid(color(0, 18, 0));
+      break;
+    case Event::CaptureSuccess:
+      showSolid(color(24, 12, 0));
+      break;
+    case Event::SdError:
+      showSolid(color(24, 0, 0));
+      break;
+    case Event::Warning:
+      showSolid(color(24, 16, 0));
+      break;
+  }
+}
+
+void activityTask(void*) {
+  while (s_activityTaskRun) {
+    loop();
+    vTaskDelay(pdMS_TO_TICKS(30));
+  }
+  s_activityTask = nullptr;
+  vTaskDelete(nullptr);
+}
+
+void startActivityTask() {
+  if (s_activityTask != nullptr) {
+    return;
+  }
+  s_activityTaskRun = true;
+  xTaskCreatePinnedToCore(
+    activityTask,
+    "statusLed",
+    2048,
+    nullptr,
+    1,
+    &s_activityTask,
+    0
+  );
+}
+}
+
+void begin() {
+  s_available = pinIsValid() && STATUS_LED_COUNT > 0;
+  s_started = false;
+  s_eventActive = false;
+  s_mode = Mode::Off;
+
+  if (!s_available) {
+    return;
+  }
+
+  s_pixels.begin();
+  s_pixels.setBrightness(kBrightness);
+  clearPixels();
+  s_pixels.show();
+  s_started = true;
+}
+
+void loop() {
+  if (!s_started) {
+    return;
+  }
+
+  if (!enabled()) {
+    clearPixels();
+    s_pixels.show();
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (s_eventActive) {
+    if ((int32_t)(now - s_eventUntilMs) >= 0) {
+      s_eventActive = false;
+    } else {
+      renderEvent();
+      return;
+    }
+  }
+
+  if ((uint32_t)(now - s_lastFrameMs) < kFrameMs) {
+    return;
+  }
+
+  s_lastFrameMs = now;
+  ++s_phase;
+  renderMode();
+}
+
+void setMode(Mode mode) {
+  s_mode = mode;
+  s_phase = 0;
+  s_lastFrameMs = 0;
+  if (s_started && enabled()) {
+    renderMode();
+  }
+}
+
+void startActivity(Mode mode) {
+  setMode(mode);
+  if (s_started && enabled()) {
+    startActivityTask();
+  }
+}
+
+void stopActivity(Mode nextMode) {
+  s_activityTaskRun = false;
+  setMode(nextMode);
+}
+
+void event(Event event) {
+  if (!s_started || !enabled()) {
+    return;
+  }
+
+  s_event = event;
+  s_eventActive = true;
+  s_eventUntilMs = millis() + kEventMs;
+  renderEvent();
+}
+
+void off() {
+  s_mode = Mode::Off;
+  s_eventActive = false;
+  if (s_started) {
+    clearPixels();
+    s_pixels.show();
+  }
+}
+}

--- a/ESP32-DIV/StatusLedService.h
+++ b/ESP32-DIV/StatusLedService.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace StatusLedService {
+enum class Mode : uint8_t {
+  Off,
+  Boot,
+  Idle,
+  WifiScan,
+  BleScan,
+  SubGhzActivity,
+  Nrf24Activity,
+  SdError,
+  BatteryLow,
+  GpsSearching,
+  GpsFix
+};
+
+enum class Event : uint8_t {
+  BootOk,
+  CaptureSuccess,
+  SdError,
+  Warning
+};
+
+void begin();
+void loop();
+void setMode(Mode mode);
+void startActivity(Mode mode);
+void stopActivity(Mode nextMode = Mode::Idle);
+void event(Event event);
+void off();
+}

--- a/ESP32-DIV/bluetooth.cpp
+++ b/ESP32-DIV/bluetooth.cpp
@@ -5,6 +5,7 @@
 #include "freertos/task.h"
 #include "icon.h"
 #include "shared.h"
+#include "StatusLedService.h"
 #include "utils.h"
 
 #ifdef TFT_BLACK
@@ -1537,17 +1538,24 @@ static void bgBleScanTask(void* ) {
       }
       bgBleScanRunning = true;
       isScanning = true;
+      setStatusBarBleState(StatusBarRadioState::Scanning);
       bleResults = bleScan->start(2, false);
       isScanning = false;
       bgBleScanRunning = false;
       if (bleResults.getCount() >= 0) {
         bgHasResults = (bleResults.getCount() > 0);
         bgLastScanMs = now;
+        setStatusBarBleState((bleResults.getCount() > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
+      } else {
+        setStatusBarBleState(StatusBarRadioState::Error);
       }
       vTaskDelay(BG_BLE_SCAN_INTERVAL_MS / portTICK_PERIOD_MS);
     } else {
       if (bgBleScanRunning) {
         stopBgBleScanIfRunning();
+      }
+      if (!settings().autoBleScan) {
+        setStatusBarBleState(StatusBarRadioState::Off);
       }
       vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
@@ -1582,7 +1590,6 @@ void startBLEScan() {
   if (bgBleScanRunning) {
     stopBgBleScanIfRunning();
   }
-  displayScanning();
   isDetailView = false;
   current_page = 0;
   currentIndex = 0;
@@ -1592,6 +1599,10 @@ void startBLEScan() {
   fullScreenUpdate = true;
   ensureBleInit();
   fgBleScanInProgress = true;
+  setStatusBarBleState(StatusBarRadioState::Scanning);
+  drawStatusBar(currentBatteryVoltage, true);
+  StatusLedService::startActivity(StatusLedService::Mode::BleScan);
+  displayScanning();
   bleResults = bleScan->start(5, false);
   fgBleScanInProgress = false;
   isScanning = false;
@@ -1600,7 +1611,12 @@ void startBLEScan() {
   if (bleResults.getCount() >= 0) {
     bgHasResults = (bleResults.getCount() > 0);
     bgLastScanMs = millis();
+    setStatusBarBleState((bleResults.getCount() > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
+  } else {
+    setStatusBarBleState(StatusBarRadioState::Error);
   }
+  StatusLedService::stopActivity(StatusLedService::Mode::Idle);
+  drawStatusBar(currentBatteryVoltage, true);
 }
 
 void handleButtons() {
@@ -2020,7 +2036,6 @@ void startBackgroundScanner() {
 
 int getLastCount() {
 
-  if (!settings().autoBleScan) return 0;
   return bleResults.getCount();
 }
 
@@ -2033,6 +2048,7 @@ void exit() {
     bleScan->stop();
     isScanning = false;
   }
+  setStatusBarBleState(StatusBarRadioState::Off);
 }
 }
 

--- a/ESP32-DIV/shared.h
+++ b/ESP32-DIV/shared.h
@@ -248,7 +248,16 @@ static const uint8_t OBF_WB[]   = {75, 97, 110, 109, 122, 92, 109, 107, 96, 38, 
 /* Buzzer */
 #ifndef BUZZER_PIN
 // User hardware: buzzer on IO2
-#define BUZZER_PIN -1
+#define BUZZER_PIN 2
+#endif
+
+/* WS2812B status LEDs */
+#ifndef STATUS_LED_PIN
+// ESP32-DIV V2 schematic: D1 DIN is driven from IO1 through R33.
+#define STATUS_LED_PIN 1
+#endif
+#ifndef STATUS_LED_COUNT
+#define STATUS_LED_COUNT 4
 #endif
 
 /* Backlight / PWM */

--- a/ESP32-DIV/subghz.cpp
+++ b/ESP32-DIV/subghz.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <vector>
+#include "BuzzerService.h"
 #include "KeyboardUI.h"
+#include "StatusLedService.h"
 #include "Touchscreen.h"
 #include "config.h"
 #include "icon.h"
@@ -574,30 +576,6 @@ static uint16_t lastDetectAlertFreq = 0xFFFF;
 static uint32_t notifHideAtMs = 0;
 static bool notifActive = false;
 
-static constexpr uint8_t BUZZER_LEDC_CH = 7;
-static bool buzzerArmed = false;
-static uint32_t buzzerOffAtMs = 0;
-static void replayBeep(uint16_t hz = 2200, uint16_t ms = 60) {
-  #ifdef BUZZER_PIN
-  ledcSetup(BUZZER_LEDC_CH, 4000, 8);
-  ledcAttachPin(BUZZER_PIN, BUZZER_LEDC_CH);
-  ledcWriteTone(BUZZER_LEDC_CH, hz);
-  buzzerArmed = true;
-  buzzerOffAtMs = millis() + ms;
-  #endif
-}
-
-static void replayBeepPoll() {
-  #ifdef BUZZER_PIN
-  if (!buzzerArmed) return;
-  if ((int32_t)(millis() - buzzerOffAtMs) < 0) return;
-  ledcWriteTone(BUZZER_LEDC_CH, 0);
-
-  ledcDetachPin(BUZZER_PIN);
-  buzzerArmed = false;
-  #endif
-}
-
 static void replayShowDetectNotice(const String& reason, int rssi = 0) {
   uint32_t now = millis();
 
@@ -610,7 +588,8 @@ static void replayShowDetectNotice(const String& reason, int rssi = 0) {
 
   snprintf(msg, sizeof(msg), "%s @ %.2f MHz | RSSI %d", reason.c_str(), mhz, rssi);
   showNotificationActions("SubGHz Detected", msg, true);
-  replayBeep(reason == "DECODE" ? 2600 : 2000, 70);
+  BuzzerService::beepCapture();
+  StatusLedService::event(StatusLedService::Event::CaptureSuccess);
   notifActive = true;
   notifHideAtMs = 0;
 }
@@ -1412,7 +1391,7 @@ void ReplayAttackLoop() {
     const bool upPressed    = isPhysicalButtonPressed(BTN_UP);
     const bool downPressed  = isPhysicalButtonPressed(BTN_DOWN);
 
-    replayBeepPoll();
+    BuzzerService::loop();
 
     if (notifActive && isNotificationVisible()) {
       int x, y;

--- a/ESP32-DIV/utils.cpp
+++ b/ESP32-DIV/utils.cpp
@@ -464,30 +464,55 @@ bool lastSdCardState = false;
 static TaskHandle_t statusBarTaskHandle = nullptr;
 static volatile bool statusBarDirty = true;
 static constexpr uint32_t kStatusBarWardBlinkHalfMs = 900;
+static volatile StatusBarRadioState s_wifiStatus = StatusBarRadioState::Off;
+static volatile StatusBarRadioState s_bleStatus = StatusBarRadioState::Off;
 
 void requestStatusBarRedraw() {
   statusBarDirty = true;
+}
+
+void setStatusBarWifiState(StatusBarRadioState state) {
+  if (s_wifiStatus == state) return;
+  s_wifiStatus = state;
+  requestStatusBarRedraw();
+}
+
+void setStatusBarBleState(StatusBarRadioState state) {
+  if (s_bleStatus == state) return;
+  s_bleStatus = state;
+  requestStatusBarRedraw();
+}
+
+StatusBarRadioState getStatusBarWifiState() {
+  return s_wifiStatus;
+}
+
+StatusBarRadioState getStatusBarBleState() {
+  return s_bleStatus;
 }
 
 const float R1 = 100000.0;
 const float R2 = 100000.0;
 
 float readBatteryVoltage() {
+  #if !defined(BATTERY_ADC_PIN) || (BATTERY_ADC_PIN < 0)
+  return NAN;
+  #else
   const int sampleCount = 10;
   long sum = 0;
 
   for (int i = 0; i < sampleCount; i++) {
     sum += analogRead(BATTERY_ADC_PIN);
-    delay(5);
   }
 
   float averageADC = sum / (float)sampleCount;
 
-  float pinVoltage = (averageADC / 4095.0) * 2.2;
+  float pinVoltage = (averageADC / 4095.0f) * 3.3f;
 
-  float outputVoltage = pinVoltage * 2.0;
+  float outputVoltage = pinVoltage * ((BATTERY_VDIV_R1 + BATTERY_VDIV_R2) / BATTERY_VDIV_R2);
 
   return outputVoltage;
+  #endif
 }
 
 float readInternalTemperature() {
@@ -533,17 +558,53 @@ static int statusBarTempBand(float t) {
   return 0;
 }
 
+static uint16_t statusBarRadioColor(StatusBarRadioState state, int count, uint16_t activeColor) {
+  switch (state) {
+    case StatusBarRadioState::Scanning:
+      return TFT_YELLOW;
+    case StatusBarRadioState::Active:
+      return activeColor;
+    case StatusBarRadioState::Error:
+      return TFT_RED;
+    case StatusBarRadioState::Off:
+    default:
+      return (count > 0) ? activeColor : TFT_WHITE;
+  }
+}
+
+static void drawStatusBarUsbBatteryIcon(int x, int y, uint16_t color, uint16_t bg) {
+  tft.fillRect(x, y, 26, 14, bg);
+  tft.fillRoundRect(x, y + 1, 21, 12, 2, color);
+  tft.fillRoundRect(x + 21, y + 4, 4, 6, 1, color);
+
+  const int boltX[7] = {
+    x + 11, x + 7, x + 10, x + 8, x + 15, x + 12, x + 14
+  };
+  const int boltY[7] = {
+    y + 3, y + 8, y + 8, y + 12, y + 5, y + 5, y + 3
+  };
+  tft.fillTriangle(boltX[0], boltY[0], boltX[1], boltY[1], boltX[2], boltY[2], bg);
+  tft.fillTriangle(boltX[3], boltY[3], boltX[4], boltY[4], boltX[5], boltY[5], bg);
+  tft.drawLine(boltX[2], boltY[2], boltX[3], boltY[3], bg);
+}
+
 void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator) {
   static int lastBatteryPercentage = -1;
   static int lastWifiHalf          = -100000;
   static int lastBleHalf           = -100000;
+  static StatusBarRadioState lastWifiState = StatusBarRadioState::Off;
+  static StatusBarRadioState lastBleState  = StatusBarRadioState::Off;
   static int lastTempBand          = -100;
   static int lastSdSnap            = -1;
   static bool lastWardGpsIcon      = false;
   static uint32_t lastWardBlinkPhase = 0;
 
-  int batteryPercentage = ::map(batteryVoltage * 100, 300, 420, 0, 100);
-  batteryPercentage = constrain(batteryPercentage, 0, 100);
+  const bool batteryKnown = isfinite(batteryVoltage) && batteryVoltage > 0.1f;
+  int batteryPercentage = -1;
+  if (batteryKnown) {
+    batteryPercentage = ::map(batteryVoltage * 100, 300, 420, 0, 100);
+    batteryPercentage = constrain(batteryPercentage, 0, 100);
+  }
 
   int wifiDevices = 0;
   int bleDevices  = 0;
@@ -553,6 +614,8 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
 
   const int wifiHalf = wifiDevices / 2;
   const int bleHalf  = bleDevices / 2;
+  const StatusBarRadioState wifiState = getStatusBarWifiState();
+  const StatusBarRadioState bleState  = getStatusBarBleState();
 
   const bool wardGpsIcon = GpsWardriver::statusBarGpsIconActive();
   const uint32_t wardBlinkPhase =
@@ -569,7 +632,8 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
   const bool wardBlinkOnly =
       !forceUpdate && wardGpsIcon && lastWardGpsIcon &&
       (wardBlinkPhase != lastWardBlinkPhase) && !battCh && wifiHalf == lastWifiHalf &&
-      bleHalf == lastBleHalf && tempBand == lastTempBand && sdSnap == lastSdSnap;
+      bleHalf == lastBleHalf && wifiState == lastWifiState && bleState == lastBleState &&
+      tempBand == lastTempBand && sdSnap == lastSdSnap;
 
   if (wardBlinkOnly) {
     constexpr int kBarH   = 20;
@@ -592,7 +656,8 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
     return;
   }
 
-  if (battCh || wifiHalf != lastWifiHalf || bleHalf != lastBleHalf || tempBand != lastTempBand ||
+  if (battCh || wifiHalf != lastWifiHalf || bleHalf != lastBleHalf ||
+      wifiState != lastWifiState || bleState != lastBleState || tempBand != lastTempBand ||
       sdSnap != lastSdSnap || wardGpsIcon != lastWardGpsIcon ||
       (wardGpsIcon && wardBlinkPhase != lastWardBlinkPhase) || forceUpdate) {
     int barHeight = 20;
@@ -601,18 +666,24 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
 
     tft.fillRect(0, 0, tft.width(), barHeight, UI_LABLE);
 
-    tft.drawRoundRect(x, y, 22, 10, 2, TFT_WHITE);
-    tft.fillRect(x + 22, y + 3, 2, 4, TFT_WHITE);
+    if (batteryKnown) {
+      tft.drawRoundRect(x, y, 22, 10, 2, TFT_WHITE);
+      tft.fillRect(x + 22, y + 3, 2, 4, TFT_WHITE);
 
-    int batteryLevelWidth = ::map(batteryPercentage, 0, 100, 0, 20);
-    uint16_t batteryColor = (batteryPercentage > 20) ? TFT_GREEN : TFT_RED;
-    tft.fillRoundRect(x + 2, y + 2, batteryLevelWidth, 6, 1, batteryColor);
+      int batteryLevelWidth = ::map(batteryPercentage, 0, 100, 0, 20);
+      uint16_t batteryColor = (batteryPercentage > 20) ? TFT_GREEN : TFT_RED;
+      tft.fillRoundRect(x + 2, y + 2, batteryLevelWidth, 6, 1, batteryColor);
+    } else {
+      drawStatusBarUsbBatteryIcon(x, y - 1, TFT_GREEN, UI_LABLE);
+    }
 
-    tft.setCursor(x + 30, y + 2);
     tft.setTextColor(TFT_GREEN, UI_LABLE);
     tft.setTextFont(1);
     tft.setTextSize(1);
-    tft.print(String(batteryPercentage) + "%");
+    if (batteryKnown) {
+      tft.setCursor(x + 30, y + 2);
+      tft.print(String(batteryPercentage) + "%");
+    }
 
     const int iconW         = 16;
     const int gap           = 3;
@@ -634,8 +705,8 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
       tft.drawBitmap(wardGpsX, iconY, bitmap_icon_satellite, iconW, iconW, TFT_ORANGE);
     }
 
-    uint16_t wifiColor = (wifiDevices > 0) ? TFT_GREEN : TFT_WHITE;
-    uint16_t bleColor  = (bleDevices  > 0) ? TFT_CYAN  : TFT_WHITE;
+    uint16_t wifiColor = statusBarRadioColor(wifiState, wifiDevices, TFT_GREEN);
+    uint16_t bleColor  = statusBarRadioColor(bleState, bleDevices, TFT_CYAN);
 
     int wifiStrength = 0;
     if (wifiDevices > 0) {
@@ -652,7 +723,7 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
       const int barX      = wifiX + i * 6;
 
       if (wifiStrength > i * 25) {
-        tft.fillRoundRect(barX, wifiY - sigBarH, barWidth, sigBarH, 1, TFT_GREEN);
+        tft.fillRoundRect(barX, wifiY - sigBarH, barWidth, sigBarH, 1, wifiColor);
       } else {
         tft.drawRoundRect(barX, wifiY - sigBarH, barWidth, sigBarH, 1, TFT_WHITE);
       }
@@ -682,6 +753,8 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
     lastBatteryPercentage = batteryPercentage;
     lastWifiHalf          = wifiHalf;
     lastBleHalf           = bleHalf;
+    lastWifiState         = wifiState;
+    lastBleState          = bleState;
     lastTempBand          = tempBand;
     lastSdSnap            = sdSnap;
     lastWardGpsIcon       = wardGpsIcon;
@@ -693,6 +766,8 @@ static void statusBarTask(void* ) {
   static int prevBattPct    = -1;
   static int prevWifiHalf   = -100000;
   static int prevBleHalf    = -100000;
+  static StatusBarRadioState prevWifiState = StatusBarRadioState::Off;
+  static StatusBarRadioState prevBleState  = StatusBarRadioState::Off;
   static int prevTempBand   = -100;
   static int prevSdSnap     = -1;
   static bool prevWardIcon  = false;
@@ -703,13 +778,16 @@ static void statusBarTask(void* ) {
     const float v = readBatteryVoltage();
     currentBatteryVoltage = v;
 
-    const int pct = constrain(::map((int)(v * 100.f), 300, 420, 0, 100), 0, 100);
+    const bool batteryKnown = isfinite(v) && v > 0.1f;
+    const int pct = batteryKnown ? constrain(::map((int)(v * 100.f), 300, 420, 0, 100), 0, 100) : -1;
     const int wifi  = WifiScan::getLastCount();
     const int ble   = BleScan::getLastCount();
     const int wifiH = wifi / 2;
     const int bleH  = ble / 2;
     const int tBand = statusBarTempBand(readInternalTemperature());
     const int sdSn  = sdCardPresent ? 1 : 0;
+    const StatusBarRadioState wifiState = getStatusBarWifiState();
+    const StatusBarRadioState bleState = getStatusBarBleState();
     const bool ward = GpsWardriver::statusBarGpsIconActive();
     const uint32_t wPh = ward ? (millis() / kStatusBarWardBlinkHalfMs) : 0u;
 
@@ -718,6 +796,9 @@ static void statusBarTask(void* ) {
       need = true;
     }
     if (wifiH != prevWifiHalf || bleH != prevBleHalf) {
+      need = true;
+    }
+    if (wifiState != prevWifiState || bleState != prevBleState) {
       need = true;
     }
     if (tBand != prevTempBand || sdSn != prevSdSnap) {
@@ -735,6 +816,8 @@ static void statusBarTask(void* ) {
       prevBattPct     = pct;
       prevWifiHalf    = wifiH;
       prevBleHalf     = bleH;
+      prevWifiState   = wifiState;
+      prevBleState    = bleState;
       prevTempBand    = tBand;
       prevSdSnap      = sdSn;
       prevWardIcon    = ward;

--- a/ESP32-DIV/utils.h
+++ b/ESP32-DIV/utils.h
@@ -30,6 +30,18 @@ void startStatusBarTask();
 /** Request a status bar pass on the next update (e.g. after SD or ward state changes). */
 void requestStatusBarRedraw();
 
+enum class StatusBarRadioState : uint8_t {
+  Off,
+  Scanning,
+  Active,
+  Error
+};
+
+void setStatusBarWifiState(StatusBarRadioState state);
+void setStatusBarBleState(StatusBarRadioState state);
+StatusBarRadioState getStatusBarWifiState();
+StatusBarRadioState getStatusBarBleState();
+
 extern bool feature_exit_requested;
 
 extern void setBrightness(uint8_t value);
@@ -154,4 +166,3 @@ namespace FeatureUI {
 }
 
 #endif
- 

--- a/ESP32-DIV/wifi.cpp
+++ b/ESP32-DIV/wifi.cpp
@@ -10,6 +10,7 @@
 #include "freertos/task.h"
 #include "icon.h"
 #include "shared.h"
+#include "StatusLedService.h"
 #include "utils.h"
 
 /** Active-scan dwell per channel for STA scans (Arduino default 300 ms; shared.h WIFI_SCAN_ACTIVE_MS). */
@@ -1974,6 +1975,7 @@ static void bgWifiScanTask(void* ) {
     if (settings().autoWifiScan && idleOk && !feature_active && !in_sub_menu) {
 
       if (!bgScanRunning) {
+        setStatusBarWifiState(StatusBarRadioState::Scanning);
         WiFi.mode(WIFI_STA);
         WiFi.disconnect();
         WiFi.scanDelete();
@@ -1985,9 +1987,11 @@ static void bgWifiScanTask(void* ) {
 
           bgHasResults = true;
           bgLastScanMs = now;
+          setStatusBarWifiState((ret > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
           vTaskDelay(BG_SCAN_INTERVAL_MS / portTICK_PERIOD_MS);
         } else if (!bgScanRunning) {
 
+          setStatusBarWifiState(StatusBarRadioState::Error);
           vTaskDelay(2000 / portTICK_PERIOD_MS);
         } else {
           vTaskDelay(250 / portTICK_PERIOD_MS);
@@ -1998,10 +2002,12 @@ static void bgWifiScanTask(void* ) {
           bgHasResults = true;
           bgLastScanMs = now;
           bgScanRunning = false;
+          setStatusBarWifiState((n > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
           vTaskDelay(BG_SCAN_INTERVAL_MS / portTICK_PERIOD_MS);
         } else if (n == WIFI_SCAN_FAILED) {
           bgScanRunning = false;
           WiFi.scanDelete();
+          setStatusBarWifiState(StatusBarRadioState::Error);
           vTaskDelay(2000 / portTICK_PERIOD_MS);
         } else {
 
@@ -2012,6 +2018,9 @@ static void bgWifiScanTask(void* ) {
       // Only cancel our async background scan — sync feature scans also report RUNNING.
       if (bgScanRunning) {
         stopBgWifiScanIfRunning();
+      }
+      if (!settings().autoWifiScan) {
+        setStatusBarWifiState(StatusBarRadioState::Off);
       }
       vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
@@ -2033,7 +2042,6 @@ void startBackgroundScanner() {
 
 int getLastCount() {
 
-  if (!settings().autoWifiScan) return 0;
   int n = WiFi.scanComplete();
   return (n < 0) ? 0 : n;
 }
@@ -2054,11 +2062,15 @@ int staWifiScanSync() {
   delay(50);
   const uint32_t dwell = wifiStaScanMsPerChannel();
   fgWifiScanInProgress = true;
+  setStatusBarWifiState(StatusBarRadioState::Scanning);
   const int n = WiFi.scanNetworks(false, true, false, dwell);
   fgWifiScanInProgress = false;
   if (n >= 0) {
     bgHasResults = true;
     bgLastScanMs = millis();
+    setStatusBarWifiState((n > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
+  } else {
+    setStatusBarWifiState(StatusBarRadioState::Error);
   }
   return n;
 }
@@ -2286,6 +2298,10 @@ void startWiFiScan() {
   currentIndex = 0;
   listStartIndex = 0;
 
+  setStatusBarWifiState(StatusBarRadioState::Scanning);
+  drawStatusBar(currentBatteryVoltage, true);
+  StatusLedService::startActivity(StatusLedService::Mode::WifiScan);
+
   displayScanning();
 
   pauseBackgroundRadioTasks();
@@ -2305,6 +2321,8 @@ void startWiFiScan() {
         (void)esp_wifi_scan_stop();
         fgWifiScanInProgress = false;
         isScanning = false;
+        setStatusBarWifiState(StatusBarRadioState::Off);
+        StatusLedService::stopActivity(StatusLedService::Mode::Idle);
         feature_exit_requested = true;
         return;
       }
@@ -2318,7 +2336,12 @@ void startWiFiScan() {
   if (numNetworks >= 0) {
     bgHasResults = true;
     bgLastScanMs = millis();
+    setStatusBarWifiState((numNetworks > 0) ? StatusBarRadioState::Active : StatusBarRadioState::Off);
+  } else {
+    setStatusBarWifiState(StatusBarRadioState::Error);
   }
+  StatusLedService::stopActivity(StatusLedService::Mode::Idle);
+  drawStatusBar(currentBatteryVoltage, true);
 
   displayWiFiList(true);
 }
@@ -4246,7 +4269,7 @@ static void deautherOpenTarget(int index) {
   drawAttackScreen();
 }
 
-extern "C" int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3) {
+extern "C" __attribute__((weak)) int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3) {
     return 0;
 }
 


### PR DESCRIPTION
Adds ESP32-DIV V2 hardware support improvements for ESP32-S3 boards:

- Non-blocking integrated buzzer feedback
- Non-blocking WS2812B status LED service
- Real Wi-Fi/BLE status bar state handling
- USB-powered battery indicator when battery ADC is unavailable
- Safer battery fallback when no ADC pin is configured
- Initial V2 hardware pin map documentation

Validated on ESP32-DIV V2:
- Buzzer on GPIO 2
- WS2812B DIN on GPIO 1
- Wi-Fi/BLE scan status LEDs
- Wi-Fi/BLE status bar indicators
- USB-powered battery icon

Build tested with Arduino CLI and ESP32-S3 16MB/DIO profile.