### PR TITLE
Fix/main menu tap select

### DIFF
--- a/ESP32-DIV/ESP32-DIV.ino
+++ b/ESP32-DIV/ESP32-DIV.ino
@@ -4530,41 +4530,42 @@ void handleButtons() {
                     last_interaction_time = millis();
                     displayMenu();
 
+                    // Tap-to-select: any tap that lands on a tile activates it.
+                    // Wait (bounded) for the finger to lift so we act once per
+                    // tap, instead of requiring the touch to still be held after
+                    // 100 ms (which made quick taps only highlight, not enter).
                     unsigned long startTime = millis();
-                    while (isTouchDownDismiss() && (millis() - startTime < touchFeedbackDelay)) {
-                        delay(10);
+                    while (isTouchDownDismiss() && (millis() - startTime < 600)) {
+                        delay(5);
                     }
 
-                    if (isTouchDownDismiss()) {
+                    if (current_menu_index == 3) {
+                        handleSettingsSubmenuButtons();
+                    } else if (current_menu_index == 7) {
+                        handleAboutPage();
+                    } else {
+                        updateActiveSubmenu();
 
-                        if (current_menu_index == 3) {
-                            handleSettingsSubmenuButtons();
-                        } else if (current_menu_index == 7) {
-                            handleAboutPage();
+                        if (active_submenu_items && active_submenu_size > 0) {
+                            current_submenu_index = 0;
+                            if (current_menu_index == 2) {
+                                other_layer = OTHER_LAYER_HOME;
+                                other_menu_grid_initialized = false;
+                                last_other_menu_index = -1;
+                            }
+                            in_sub_menu = true;
+                            submenu_initialized = false;
+                            displaySubmenu();
                         } else {
-                            updateActiveSubmenu();
-
-                            if (active_submenu_items && active_submenu_size > 0) {
-                                current_submenu_index = 0;
-                                if (current_menu_index == 2) {
-                                    other_layer = OTHER_LAYER_HOME;
-                                    other_menu_grid_initialized = false;
-                                    last_other_menu_index = -1;
-                                }
-                                in_sub_menu = true;
-                                submenu_initialized = false;
-                                displaySubmenu();
+                            if (is_main_menu) {
+                                is_main_menu = false;
+                                displayMenu();
                             } else {
-                                if (is_main_menu) {
-                                    is_main_menu = false;
-                                    displayMenu();
-                                } else {
-                                    is_main_menu = true;
-                                }
+                                is_main_menu = true;
                             }
                         }
                     }
-                    delay(200);
+                    delay(150);
                     break;
                 }
             }


### PR DESCRIPTION
improved menu responsiveness.

The problem: The old code was picky. When you tapped a button, it lit up - but the screen only actually went there if you kept your finger pressed down for a little while. If you tapped quick, like people normally do, it just lit up and did nothing. So you'd tap again... and again... "Why won't it work?"

It's like an elevator button that only counts if you press it and hold it. A normal quick press just makes it glow but doesn't call the elevator.

The fix: I told it, "If someone taps a button, that means they want it - just go!" Now a quick tap works right away. No holding needed.

That's the whole trick: before, it waited to see if you were still pressing. Now, one tap = go.